### PR TITLE
fix: respect classname in card components

### DIFF
--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -83,6 +83,7 @@ export const UserAuthCard = ({
   cardImage,
   onSubmit,
   includeScripts,
+  className,
 }: UserAuthCardProps): JSX.Element => {
   if (includeScripts) {
     useScriptNodes({ nodes: flow.ui.nodes })
@@ -262,6 +263,7 @@ export const UserAuthCard = ({
 
   return (
     <Card
+      className={className}
       heading={
         <h2 className={typographyStyle({ type: "regular", size: "small" })}>
           {title}

--- a/src/react-components/ory/user-consent-card.tsx
+++ b/src/react-components/ory/user-consent-card.tsx
@@ -20,6 +20,7 @@ export type UserConsentCardProps = {
   requested_scope?: string[]
   client?: OAuth2Client
   action: string
+  className?: string
 }
 
 export const UserConsentCard = ({
@@ -30,9 +31,11 @@ export const UserConsentCard = ({
   requested_scope = [],
   client,
   action,
+  className,
 }: UserConsentCardProps) => {
   return (
     <Card
+      className={className}
       heading={
         <div style={{ textAlign: "center" }}>
           <Typography type="bold">{client_name}</Typography>

--- a/src/react-components/ory/user-error-card.tsx
+++ b/src/react-components/ory/user-error-card.tsx
@@ -13,6 +13,7 @@ export type UserErrorCardProps = {
   backUrl: string
   cardImage?: string | React.ReactElement
   contactSupportEmail?: string
+  className?: string
 }
 
 type errorMessage = {
@@ -29,12 +30,14 @@ export const UserErrorCard = ({
   backUrl,
   cardImage,
   contactSupportEmail,
+  className,
 }: UserErrorCardProps): JSX.Element => {
   const err = error.error as errorMessage
   const status = err.code
   const message = status >= 500 ? JSON.stringify(error, null, 2) : err.reason
   return (
     <Card
+      className={className}
       heading={
         <h2 className={typographyStyle({ type: "regular", size: "small" })}>
           {title}

--- a/src/react-components/ory/user-settings-card.tsx
+++ b/src/react-components/ory/user-settings-card.tsx
@@ -33,6 +33,7 @@ export type UserSettingsCardProps = {
   flowType: UserSettingsFlowType
   title?: string
   includeScripts?: boolean
+  className?: string
 } & UserAuthFormAdditionalProps
 
 export const UserSettingsCard = ({
@@ -41,6 +42,7 @@ export const UserSettingsCard = ({
   title,
   includeScripts,
   onSubmit,
+  className,
 }: UserSettingsCardProps): JSX.Element | null => {
   if (includeScripts) {
     useScriptNodes({ nodes: flow.ui.nodes })
@@ -107,7 +109,7 @@ export const UserSettingsCard = ({
           {cardTitle}
         </h3>
       )}
-      <UserAuthForm flow={flow} onSubmit={onSubmit}>
+      <UserAuthForm flow={flow} onSubmit={onSubmit} className={className}>
         {$flow}
       </UserAuthForm>
     </div>

--- a/src/theme/checkbox.css.ts
+++ b/src/theme/checkbox.css.ts
@@ -7,7 +7,7 @@ import { oryTheme } from "./theme.css"
 
 export const checkboxStyle = style({
   display: "flex",
-  justifyContent: "start",
+  justifyContent: "flex-start",
   alignItems: "center",
   cursor: "pointer",
   gap: pxToRem(8),


### PR DESCRIPTION
I was playing around with elements, and saw the UserAuthCard have the className which wasn't being respected. I determined that this should be passed down to the Card component. I have also fixed this on the other card components.

It is useful for playing around with un-themeable things such as card width. (There is for instance a max-width set on the component, which I would like to unset).

I also included a small fix for using `justify-content: start`, which blows up my build log with this error: `[vite:css] start value has mixed support, consider using flex-start instead`. It then proceeds to print the line where the error is, but since the css is minified, it prints the whole style.css to my log.
![image](https://user-images.githubusercontent.com/13065402/201505893-b47555ac-d54c-4066-8ef0-7d8b59856b85.png)

## Related Issue or Design Document
An issue would be too much overhead for this small fix.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).

## Further comments
If this isn't how className was supposed to be implemented, you are welcome to close this PR.