### PR TITLE
fix: handle success state of message

### DIFF
--- a/src/react-components/message.tsx
+++ b/src/react-components/message.tsx
@@ -1,6 +1,6 @@
 import cn from "classnames"
 import React from "react"
-import { MessageStyle, messageStyle, typographyStyle } from "../theme"
+import { MessageStyle, messageStyle, Severity, typographyStyle } from "../theme"
 
 // required since interfaces cannot extend types whose properties are not statically known
 export type MessageStyleProps = MessageStyle & Record<string, unknown>

--- a/src/react-components/ory/helpers/error-messages.tsx
+++ b/src/react-components/ory/helpers/error-messages.tsx
@@ -1,5 +1,5 @@
 import { UiNode, UiText } from "@ory/client"
-import { GridStyle, gridStyle } from "../../../theme"
+import { GridStyle, gridStyle, Severity } from "../../../theme"
 import { Message, MessageStyleProps } from "../../message"
 
 export type NodeMessagesProps = {
@@ -19,7 +19,7 @@ const nodeMessage = ({ text, id, type, key, ...props }: nodeMessageProps) => (
   <Message
     key={key}
     data-testid={`ui/message/${id}`}
-    severity={type === "info" ? "success" : "error"}
+    severity={type as Severity}
     {...props}
   >
     {text}

--- a/src/theme/message.css.ts
+++ b/src/theme/message.css.ts
@@ -4,7 +4,22 @@
 import { recipe, RecipeVariants } from "@vanilla-extract/recipes"
 import { oryTheme } from "./theme.css"
 
-export const messageStyle = recipe({
+const SeverityTypes = [
+  "error",
+  "success",
+  "info",
+  "disabled",
+  "default",
+] as const
+
+export type Severity = typeof SeverityTypes[number]
+
+type MessageVariants = {
+  textPosition: Record<string, any>
+  severity: Record<Severity, any>
+}
+
+export const messageStyle = recipe<MessageVariants>({
   base: {
     boxSizing: "border-box",
     display: "flex",
@@ -30,6 +45,9 @@ export const messageStyle = recipe({
       },
       success: {
         color: oryTheme.success.emphasis,
+      },
+      info: {
+        color: oryTheme.foreground.def,
       },
       disabled: {
         color: oryTheme.foreground.disabled,


### PR DESCRIPTION
Add missing `success` state to be handled via UI. 

## Related Issue or Design Document

https://github.com/ory-corp/cloud/issues/3221

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
