### PR TITLE
feat: add href handler for ButtonLink component

### DIFF
--- a/src/react-components/button-link.tsx
+++ b/src/react-components/button-link.tsx
@@ -1,4 +1,5 @@
 import cn from "classnames"
+import { MouseEvent } from "react"
 
 import { typographyStyle } from "../theme"
 import {
@@ -8,12 +9,15 @@ import {
   buttonLinkStyle,
 } from "../theme/button-link.css"
 
+export type HrefWithHandler = [url: string, handler: (url: string) => void]
+export type Href = string | HrefWithHandler
+
 export type ButtonLinkProps = {
   children?: React.ReactNode
-  href?: string | undefined
+  href?: Href | undefined
   icon?: string
   className?: string
-} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
   ButtonLinkContainerStyle
 
 export const ButtonLink = ({
@@ -24,6 +28,17 @@ export const ButtonLink = ({
   position,
   ...props
 }: ButtonLinkProps): JSX.Element => {
+  let handleClick
+
+  if (Array.isArray(href)) {
+    const [realHref, handler] = href
+    href = realHref
+    handleClick = (event: MouseEvent) => {
+      event.preventDefault()
+      handler(realHref)
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -32,7 +47,12 @@ export const ButtonLink = ({
         buttonLinkContainerStyle({ position }),
       )}
     >
-      <a className={buttonLinkStyle()} href={href} {...props}>
+      <a
+        className={buttonLinkStyle()}
+        href={href}
+        onClick={handleClick}
+        {...props}
+      >
         {icon && <i className={cn(`fa fa-${icon}`, buttonLinkIconStyle)}></i>}
         {children}
       </a>

--- a/src/react-components/button-link.tsx
+++ b/src/react-components/button-link.tsx
@@ -9,12 +9,20 @@ import {
   buttonLinkStyle,
 } from "../theme/button-link.css"
 
-export type HrefWithHandler = [url: string, handler: (url: string) => void]
-export type Href = string | HrefWithHandler
+export type CustomHref = {
+  href: string
+  handler: (url: string) => void
+}
+
+const isCustomHref = (
+  href: CustomHref | string | undefined,
+): href is CustomHref => {
+  return href !== undefined && (href as CustomHref).href !== undefined
+}
 
 export type ButtonLinkProps = {
   children?: React.ReactNode
-  href?: Href | undefined
+  href?: CustomHref | string
   icon?: string
   className?: string
 } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
@@ -28,14 +36,23 @@ export const ButtonLink = ({
   position,
   ...props
 }: ButtonLinkProps): JSX.Element => {
-  let handleClick
+  let linkProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    ...props,
+  }
 
-  if (Array.isArray(href)) {
-    const [realHref, handler] = href
-    href = realHref
-    handleClick = (event: MouseEvent) => {
-      event.preventDefault()
-      handler(realHref)
+  if (isCustomHref(href)) {
+    linkProps = {
+      ...linkProps,
+      href: href.href,
+      onClick: (e: MouseEvent) => {
+        e.preventDefault()
+        href.handler(href.href)
+      },
+    }
+  } else {
+    linkProps = {
+      ...linkProps,
+      href: href,
     }
   }
 
@@ -47,12 +64,7 @@ export const ButtonLink = ({
         buttonLinkContainerStyle({ position }),
       )}
     >
-      <a
-        className={buttonLinkStyle()}
-        href={href}
-        onClick={handleClick}
-        {...props}
-      >
+      <a className={buttonLinkStyle()} {...linkProps}>
         {icon && <i className={cn(`fa fa-${icon}`, buttonLinkIconStyle)}></i>}
         {children}
       </a>

--- a/src/react-components/ory/helpers/common.tsx
+++ b/src/react-components/ory/helpers/common.tsx
@@ -1,5 +1,5 @@
 import { colorSprinkle } from "../../../theme"
-import { ButtonLink } from "../../button-link"
+import { ButtonLink, Href } from "../../button-link"
 import { Message } from "../../message"
 
 export type ErrorProps = {
@@ -15,14 +15,14 @@ export type ErrorProps = {
 }
 
 export type AdditionalProps = {
-  forgotPasswordURL?: string
-  signupURL?: string
-  logoutURL?: string
-  loginURL?: string
+  forgotPasswordURL?: Href
+  signupURL?: Href
+  logoutURL?: Href
+  loginURL?: Href
 }
 
 export type MessageSectionProps = {
-  url: string | undefined
+  url: Href | undefined
   buttonText: string
   dataTestId?: string
   text?: React.ReactNode

--- a/src/react-components/ory/helpers/common.tsx
+++ b/src/react-components/ory/helpers/common.tsx
@@ -1,5 +1,5 @@
 import { colorSprinkle } from "../../../theme"
-import { ButtonLink, Href } from "../../button-link"
+import { ButtonLink, CustomHref } from "../../button-link"
 import { Message } from "../../message"
 
 export type ErrorProps = {
@@ -15,14 +15,14 @@ export type ErrorProps = {
 }
 
 export type AdditionalProps = {
-  forgotPasswordURL?: Href
-  signupURL?: Href
-  logoutURL?: Href
-  loginURL?: Href
+  forgotPasswordURL?: CustomHref | string
+  signupURL?: CustomHref | string
+  logoutURL?: CustomHref | string
+  loginURL?: CustomHref | string
 }
 
 export type MessageSectionProps = {
-  url: Href | undefined
+  url?: CustomHref | string
   buttonText: string
   dataTestId?: string
   text?: React.ReactNode

--- a/src/react-components/ory/sections/login-section.tsx
+++ b/src/react-components/ory/sections/login-section.tsx
@@ -1,12 +1,12 @@
 import { UiNode } from "@ory/client"
 import { gridStyle } from "../../../theme"
-import { ButtonLink } from "../../button-link"
+import { ButtonLink, Href } from "../../button-link"
 import { FilterFlowNodes } from "../helpers/filter-flow-nodes"
 import { hasPassword } from "../helpers/utils"
 
 export type LoginSectionProps = {
   nodes: UiNode[]
-  forgotPasswordURL?: string
+  forgotPasswordURL?: Href
 }
 
 export const LoginSection = ({

--- a/src/react-components/ory/user-auth-card.spec.tsx
+++ b/src/react-components/ory/user-auth-card.spec.tsx
@@ -169,3 +169,19 @@ test("ory auth card login refresh flow", async ({ mount }) => {
   await expect(component).toContainText("You're logged in as:")
   await expect(component).toContainText("johndoe@acme.com")
 })
+
+test("ory auth card link handler", async ({ mount }) => {
+  let linkClicked = false
+
+  const component = await mount(
+    <UserAuthCard
+      flow={loginRefreshFixture}
+      flowType="login"
+      title="Verify that's you"
+      additionalProps={{ logoutURL: ["/logout", () => (linkClicked = true)] }}
+    />,
+  )
+
+  await component.locator('a:text("Logout")').click()
+  expect(linkClicked).toEqual(true)
+})

--- a/src/react-components/ory/user-auth-card.spec.tsx
+++ b/src/react-components/ory/user-auth-card.spec.tsx
@@ -178,7 +178,9 @@ test("ory auth card link handler", async ({ mount }) => {
       flow={loginRefreshFixture}
       flowType="login"
       title="Verify that's you"
-      additionalProps={{ logoutURL: ["/logout", () => (linkClicked = true)] }}
+      additionalProps={{
+        logoutURL: { href: "/logout", handler: () => (linkClicked = true) },
+      }}
     />,
   )
 

--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -2,7 +2,7 @@ import { LoginFlow } from "@ory/client"
 import { filterNodesByGroups } from "@ory/integrations/ui"
 
 import { gridStyle, typographyStyle } from "../../theme"
-import type { Href } from "../button-link.js"
+import type { CustomHref } from "../button-link"
 import { Card } from "../card"
 import { Divider } from "../divider"
 import { Message } from "../message"
@@ -30,21 +30,21 @@ import { PasswordlessSection } from "./sections/passwordless-section"
 import { RegistrationSection } from "./sections/registration-section"
 
 export type LoginSectionAdditionalProps = {
-  forgotPasswordURL?: Href
-  signupURL?: Href
-  logoutURL?: Href
+  forgotPasswordURL?: CustomHref | string
+  signupURL?: CustomHref | string
+  logoutURL?: CustomHref | string
 }
 
 export type RegistrationSectionAdditionalProps = {
-  loginURL?: Href
+  loginURL?: CustomHref | string
 }
 
 export type VerificationSectionAdditionalProps = {
-  signupURL?: Href
+  signupURL?: CustomHref | string
 }
 
 export type RecoverySectionAdditionalProps = {
-  loginURL?: Href
+  loginURL?: CustomHref | string
 }
 
 /**
@@ -61,10 +61,10 @@ export type UserAuthCardProps = {
   title: string
   flowType: "login" | "registration" | "recovery" | "verification"
   additionalProps:
-    | LoginSectionAdditionalProps
-    | RegistrationSectionAdditionalProps
-    | RecoverySectionAdditionalProps
-    | VerificationSectionAdditionalProps
+  | LoginSectionAdditionalProps
+  | RegistrationSectionAdditionalProps
+  | RecoverySectionAdditionalProps
+  | VerificationSectionAdditionalProps
   subtitle?: string
   cardImage?: string | React.ReactElement
   includeScripts?: boolean

--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -61,10 +61,10 @@ export type UserAuthCardProps = {
   title: string
   flowType: "login" | "registration" | "recovery" | "verification"
   additionalProps:
-  | LoginSectionAdditionalProps
-  | RegistrationSectionAdditionalProps
-  | RecoverySectionAdditionalProps
-  | VerificationSectionAdditionalProps
+    | LoginSectionAdditionalProps
+    | RegistrationSectionAdditionalProps
+    | RecoverySectionAdditionalProps
+    | VerificationSectionAdditionalProps
   subtitle?: string
   cardImage?: string | React.ReactElement
   includeScripts?: boolean

--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -2,6 +2,7 @@ import { LoginFlow } from "@ory/client"
 import { filterNodesByGroups } from "@ory/integrations/ui"
 
 import { gridStyle, typographyStyle } from "../../theme"
+import type { Href } from "../button-link.js"
 import { Card } from "../card"
 import { Divider } from "../divider"
 import { Message } from "../message"
@@ -29,21 +30,21 @@ import { PasswordlessSection } from "./sections/passwordless-section"
 import { RegistrationSection } from "./sections/registration-section"
 
 export type LoginSectionAdditionalProps = {
-  forgotPasswordURL?: string
-  signupURL?: string
-  logoutURL?: string
+  forgotPasswordURL?: Href
+  signupURL?: Href
+  logoutURL?: Href
 }
 
 export type RegistrationSectionAdditionalProps = {
-  loginURL?: string
+  loginURL?: Href
 }
 
 export type VerificationSectionAdditionalProps = {
-  signupURL?: string
+  signupURL?: Href
 }
 
 export type RecoverySectionAdditionalProps = {
-  loginURL?: string
+  loginURL?: Href
 }
 
 /**

--- a/src/react-components/ory/user-error-card.tsx
+++ b/src/react-components/ory/user-error-card.tsx
@@ -1,7 +1,7 @@
 import { FlowError } from "@ory/client"
 
 import { colorSprinkle, gridStyle, typographyStyle } from "../../theme"
-import { ButtonLink } from "../button-link"
+import { ButtonLink, Href } from "../button-link"
 import { Card } from "../card"
 import { CodeBox } from "../codebox"
 import { Message } from "../message"
@@ -10,7 +10,7 @@ import { Message } from "../message"
 export type UserErrorCardProps = {
   title: string
   error: FlowError
-  backUrl: string
+  backUrl: Href
   cardImage?: string | React.ReactElement
   contactSupportEmail?: string
   className?: string

--- a/src/react-components/ory/user-error-card.tsx
+++ b/src/react-components/ory/user-error-card.tsx
@@ -1,7 +1,7 @@
 import { FlowError } from "@ory/client"
 
 import { colorSprinkle, gridStyle, typographyStyle } from "../../theme"
-import { ButtonLink, Href } from "../button-link"
+import { ButtonLink, CustomHref } from "../button-link"
 import { Card } from "../card"
 import { CodeBox } from "../codebox"
 import { Message } from "../message"
@@ -10,7 +10,7 @@ import { Message } from "../message"
 export type UserErrorCardProps = {
   title: string
   error: FlowError
-  backUrl: Href
+  backUrl: CustomHref | string
   cardImage?: string | React.ReactElement
   contactSupportEmail?: string
   className?: string


### PR DESCRIPTION
Fixes #58

This PR adds the option to specify a link handler in order to make use of client side navigation. This is fully backward compatible, without introducing any new parameters which have to be passed around.

This is achieved by extending the type of `href` in the `ButtonLink` component to also accept a tuple of a URL and a handler. When this tuple is defined, the default click event will be prevented and the handler will be called with the URL.

In it's simplest form, this allows to easily use React's navigation feature like this:

```typescript
const Login = () : JSX.Element => {
    const navigate = useNavigate();

    // …
    
    return (
        <UserAuthCard
          flow={flow}
          flowType="login"
          additionalProps={{ logoutURL: ["/logout", navigate] }}
        />,
    );
};
```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
