### PR TITLE
fix: unflatten form data into correct body format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@storybook/node-logger": "6.5.16",
         "@storybook/react": "6.5.16",
         "@types/express": "^4.17.15",
+        "@types/flat": "5.0.2",
         "@types/node": "18.14.0",
         "@types/react": "18.0.27",
         "@types/react-dom": "18.0.10",
@@ -47,6 +48,7 @@
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-storybook": "0.6.11",
         "eslint-plugin-tsdoc": "0.2.17",
+        "flat": "5.0.2",
         "lerna": "5.6.2",
         "license-checker": "^25.0.1",
         "nx": "15.7.2",
@@ -9868,6 +9870,12 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -39880,6 +39888,12 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "homepage": "https://github.com/ory/elements#readme",
   "devDependencies": {
+    "@types/flat": "5.0.2",
+    "flat": "5.0.2",
     "@babel/core": "^7.18.10",
     "@ory/client": "1.1.22",
     "@ory/integrations": "1.1.0",

--- a/src/react-components/ory/helpers/user-auth-form.spec.tsx
+++ b/src/react-components/ory/helpers/user-auth-form.spec.tsx
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/experimental-ct-react"
+import {
+  AuthPage,
+  RandomString,
+  registrationFixture,
+  Traits,
+} from "../../../test"
+import { UpdateBody, UserAuthForm } from "./user-auth-form"
+import { RegistrationSection } from "../sections/registration-section"
+
+test("user auth form test", async ({ mount }) => {
+  let body: UpdateBody | undefined
+  const traits: Record<string, Traits> = {
+    "traits.firstName": {
+      group: "password",
+      label: "First Name",
+      value: RandomString(),
+      type: "input",
+    },
+    "traits.email": {
+      group: "password",
+      label: "Email",
+      value: RandomString() + "@example.com",
+      type: "input",
+    },
+    password: {
+      group: "password",
+      label: "Password",
+      value: RandomString(),
+      type: "input",
+    },
+    csrf_token: {
+      group: "default",
+      label: "",
+      value: RandomString(),
+      type: "hidden",
+    },
+  }
+  const component = await mount(
+    <UserAuthForm
+      flow={registrationFixture}
+      onSubmit={({ body: b }) => {
+        body = b
+      }}
+    >
+      <RegistrationSection nodes={registrationFixture.ui.nodes} />
+    </UserAuthForm>,
+  )
+
+  const registrationComponent = new AuthPage(traits, component)
+
+  await registrationComponent.submitForm()
+
+  expect(body).toBeTruthy()
+  expect(body).toHaveProperty("method", "password")
+  expect(body).toHaveProperty("password", traits.password.value)
+  expect(body).toHaveProperty("traits", {
+    email: traits["traits.email"].value,
+    firstName: traits["traits.firstName"].value,
+  })
+})

--- a/src/react-components/ory/helpers/user-auth-form.tsx
+++ b/src/react-components/ory/helpers/user-auth-form.tsx
@@ -7,6 +7,7 @@ import {
 } from "@ory/client"
 import { FilterNodesByGroups } from "@ory/integrations/ui"
 import cn from "classnames"
+import { unflatten } from "flat"
 
 import { formStyle } from "../../../theme"
 import { FilterFlowNodes } from "./filter-flow-nodes"
@@ -40,34 +41,6 @@ export interface UserAuthFormProps
   className?: string
 }
 
-const traitRegexp = /^traits\.(.+)$/
-
-const unflattenFormData = (formData: FormData): UpdateBody => {
-  const body: Record<string, string | object> = {}
-  const traits: Record<string, string> = {}
-
-  for (const [key, value] of formData) {
-    if (typeof value !== "string") {
-      continue
-    }
-
-    const match = traitRegexp.exec(key)
-
-    if (!match) {
-      body[key] = value
-      continue
-    }
-
-    traits[match[1]] = value
-  }
-
-  if (Object.keys(traits).length > 0) {
-    body.traits = traits
-  }
-
-  return body as unknown as UpdateBody
-}
-
 export const UserAuthForm = ({
   flow,
   children,
@@ -95,7 +68,7 @@ export const UserAuthForm = ({
         const formData = new FormData(form)
 
         // map the entire form data to JSON for the request body
-        let body = unflattenFormData(formData)
+        let body = Object.fromEntries(formData) as unknown as UpdateBody
 
         // We need the method specified from the name and value of the submit button.
         // when multiple submit buttons are present, the clicked one's value is used.
@@ -109,7 +82,7 @@ export const UserAuthForm = ({
           }
         }
 
-        onSubmit({ body, event })
+        onSubmit({ body: unflatten(body) as UpdateBody, event })
       },
     })}
     {...props}


### PR DESCRIPTION
The format for bodies with traits dictates that the traits come in through their own object. This becomes especially visible when using an SDK client compiled with a newer version of OpenAPI generator, as they only process properties which are defined in the API schema, which is not the case for flattened properties.

Fixes ory/elements-legacy#5

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
