### PR TITLE
fix: useIdWithFallback for react 17 and lower

### DIFF
--- a/src/common/useIdWithFallback.ts
+++ b/src/common/useIdWithFallback.ts
@@ -3,6 +3,8 @@
 
 import * as React from "react"
 
+const fallback = () => Math.random().toString(36).substring(2)
+
 /**
  * A function to obtain a unique ID. If react is available, this
  * is just a wrapper for React.useId(), meaning the ID will be
@@ -10,9 +12,9 @@ import * as React from "react"
  * unique ID on every call.
  */
 export const useIdWithFallback = () => {
-  try {
-    return React.useId()
-  } catch (e) {
-    return Math.random().toString(36).substring(2)
-  }
+  const useId =
+    (Object.entries(React).find(([key]) => key === "useId")?.[1] as
+      | undefined
+      | (() => string)) ?? fallback
+  return useId()
 }

--- a/src/common/useIdWithFallback.ts
+++ b/src/common/useIdWithFallback.ts
@@ -11,10 +11,8 @@ const fallback = () => Math.random().toString(36).substring(2)
  * consistent across SSR and CSR. Otherwise, it will be a random and
  * unique ID on every call.
  */
-export const useIdWithFallback = () => {
-  const useId =
-    (Object.entries(React).find(([key]) => key === "useId")?.[1] as
-      | undefined
-      | (() => string)) ?? fallback
-  return useId()
-}
+export const useIdWithFallback =
+  // This weird import circumvents webpack's exportPresence check,
+  // since we're fine if the import doesn't exist, and we don't want
+  // it to cause a build error.
+  React["useId".toString() as "useId"] ?? fallback


### PR DESCRIPTION
This PR fixes a compile error in projects using `React 17`. The change introduced in #113 implements unique IDs for components assuming that the `useId` react hook will be available. The proposed fix changes the import format to exclude the `useId` import from the build.

## Related Issue or Design Document

See conversation in #120 

![Screenshot 2023-08-04 at 13 24 24](https://github.com/ory/elements/assets/3879892/5f41e19a-672f-431f-bc8e-cc9fbd52459e)

Sample dependencies to reproduce the issue:
```json
"dependencies": {
    "@ory/elements": "0.0.1-beta.7",
    "loader-utils": "3.2.1",
    "react": "17.0.2",
    "react-dom": "17.0.2",
    "react-scripts": "5.0.1"
  },
  "devDependencies": {
    "@types/react": "17.0.2",
    "@types/react-dom": "17.0.2",
    "typescript": "5.0.2"
  },
```

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
