### PR TITLE
fix: corrects "Could not find a declaration file for module '@ory/elements'" error

### DIFF
--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -6,6 +6,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.umd.js"
     },

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -6,6 +6,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.umd.js"
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,6 +6,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.umd.js"
     },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -6,6 +6,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.umd.js"
     },


### PR DESCRIPTION
Using `exports` in `package.json` means the `types` field is no longer used and types cannot be imported and results in the error below. I have added a `types` property to `exports` field to fix the issue

```
Could not find a declaration file for module '@ory/elements'. ‘XXXX/node_modules/@ory/elements/dist/index.mjs' implicitly has an 'any' type.
  There are types at ‘XXXX/node_modules/@ory/elements/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@ory/elements' library may need to update its package.json or typings.ts(7016)
```

See https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing for details.

The original `types` fields are left in place for use by older versions of Typescript.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
