### PR TITLE
fix: settings screen group filter for lookupSecret

### DIFF
--- a/src/react-components/ory/user-settings-screen.tsx
+++ b/src/react-components/ory/user-settings-screen.tsx
@@ -147,19 +147,22 @@ const body = ({
         "webauthn",
         "totp",
       ] as UserSettingsFlowType[]
-    ).map(
-      (flowType) =>
-        flow.ui.nodes.some(({ group }) => group === flowType) && (
-          <div
-            className={settingsCardContainerClassName}
-            id={flowType}
-            key={flowType}
-          >
-            <UserSettingsCard flowType={flowType} flow={flow} />
-            <Divider fullWidth={false} className={dividerClassName} />
-          </div>
-        ),
-    )}
+    ).map((flowType) => {
+      const $card = <UserSettingsCard flowType={flowType} flow={flow} />
+      if (!$card) {
+        return null
+      }
+      return (
+        <div
+          className={settingsCardContainerClassName}
+          id={flowType}
+          key={flowType}
+        >
+          {$card}
+          <Divider fullWidth={false} className={dividerClassName} />
+        </div>
+      )
+    })}
   </>
 )
 

--- a/src/stories/Ory/SettingsScreen.stories.tsx
+++ b/src/stories/Ory/SettingsScreen.stories.tsx
@@ -1,0 +1,36 @@
+import { ComponentProps } from "react"
+import { Meta, StoryFn } from "@storybook/react"
+
+import { Container } from "../storyhelper"
+import {
+  UserSettingsScreen,
+  UserSettingsScreenProps,
+} from "../../react-components"
+import settingsFlow from "./settings-flow.json"
+import { SettingsFlow } from "@ory/client"
+
+const Screen = (props: UserSettingsScreenProps) => (
+  <div style={{ display: "flex", flexDirection: "row" }}>
+    <UserSettingsScreen.Nav {...props} />
+    <div style={{ margin: "4rem" }}>
+      <UserSettingsScreen.Body {...props} />
+    </div>
+  </div>
+)
+
+export default {
+  title: "Ory/SettingsScreen",
+  component: Screen,
+} as Meta<typeof Screen>
+
+const Template: StoryFn<ComponentProps<typeof Screen>> = (args) => (
+  <Container>
+    <Screen {...args} />
+  </Container>
+)
+
+export const SettingsScreen = Template.bind({})
+SettingsScreen.args = {
+  flow: settingsFlow as SettingsFlow,
+  logoutUrl: "https://www.ory.sh",
+}


### PR DESCRIPTION
Because the iteration string was `lookupSecret`, but the group is `lookup_secret`, that section would never be displayed.