### PR TITLE
fix: `additionalProps` should be conditional on the `UserAuthCard`

### DIFF
--- a/examples/react-spa/src/Login.tsx
+++ b/examples/react-spa/src/Login.tsx
@@ -35,7 +35,7 @@ export const Login = (): JSX.Element => {
       // flow contains the form fields and csrf token
       .then(({ data: flow }) => {
         // Update URI query params to include flow id
-        setSearchParams({})
+        setSearchParams({ ["flow"]: flow.id })
         // Set the flow data
         setFlow(flow)
       })

--- a/src/react-components/ory/user-auth-card.spec.tsx
+++ b/src/react-components/ory/user-auth-card.spec.tsx
@@ -142,6 +142,10 @@ test("ory auth card verification flow", async ({ mount }) => {
 
   await expect(component).toContainText("Verification")
   await expect(component.locator('a[href="/signup"]')).toBeVisible()
+
+  await expect(component).toContainText("Don't have an account?", {
+    ignoreCase: true,
+  })
 })
 
 test("ory auth card recovery flow", async ({ mount }) => {
@@ -238,4 +242,78 @@ test("ory auth card login with code", async ({ mount }) => {
   await expect(component.locator('button[type="submit"]')).toHaveText(
     "Sign in with code",
   )
+})
+
+test("ory auth card login should work without additionalProps", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <UserAuthCard flowType="login" flow={loginCodeFixture} />,
+  )
+
+  const loginComponent = new AuthPage(loginCodeFixture.ui.nodes, component)
+  await loginComponent.expectTraitFields()
+
+  await expect(component).toContainText("Sign in", { ignoreCase: true })
+  await expect(component).not.toContainText("Don't have an account?", {
+    ignoreCase: true,
+  })
+})
+
+test("ory auth card registration should work without additionalProps", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <UserAuthCard flowType="registration" flow={registrationCodeFixture} />,
+  )
+
+  const registrationComponent = new AuthPage(
+    registrationCodeFixture.ui.nodes,
+    component,
+  )
+  await registrationComponent.expectTraitFields()
+
+  await expect(component).toContainText("Sign up", { ignoreCase: true })
+  await expect(component).not.toContainText("Already have an account?", {
+    ignoreCase: true,
+  })
+})
+
+test("ory auth card recovery should work without additionalProps", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <UserAuthCard flowType="recovery" flow={recoveryFixture} />,
+  )
+
+  const recoveryComponent = new AuthPage(recoveryFixture.ui.nodes, component)
+  await recoveryComponent.expectTraitFields()
+
+  await expect(component).toContainText("Recover your account", {
+    ignoreCase: true,
+  })
+  await expect(component).not.toContainText("Already have an account?", {
+    ignoreCase: true,
+  })
+})
+
+test("ory auth card verification should work without additionalProps", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <UserAuthCard flowType="verification" flow={verificationFixture} />,
+  )
+
+  const verificationComponent = new AuthPage(
+    verificationFixture.ui.nodes,
+    component,
+  )
+  await verificationComponent.expectTraitFields()
+
+  await expect(component).toContainText("Verify your account", {
+    ignoreCase: true,
+  })
+  await expect(component).not.toContainText("Don't have an account?", {
+    ignoreCase: true,
+  })
 })

--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -17,7 +17,6 @@ import { MessageSection, MessageSectionProps } from "./helpers/common"
 import { NodeMessages } from "./helpers/error-messages"
 import { FilterFlowNodes } from "./helpers/filter-flow-nodes"
 import { useScriptNodes } from "./helpers/node-script"
-import { SelfServiceFlow } from "./helpers/types"
 import {
   UserAuthForm,
   UserAuthFormAdditionalProps,
@@ -76,22 +75,22 @@ export type UserAuthCardProps = {
     | {
         flow: LoginFlow
         flowType: "login"
-        additionalProps: LoginSectionAdditionalProps
+        additionalProps?: LoginSectionAdditionalProps
       }
     | {
         flow: RegistrationFlow
         flowType: "registration"
-        additionalProps: RegistrationSectionAdditionalProps
+        additionalProps?: RegistrationSectionAdditionalProps
       }
     | {
         flow: RecoveryFlow
         flowType: "recovery"
-        additionalProps: RecoverySectionAdditionalProps
+        additionalProps?: RecoverySectionAdditionalProps
       }
     | {
         flow: VerificationFlow
         flowType: "verification"
-        additionalProps: VerificationSectionAdditionalProps
+        additionalProps?: VerificationSectionAdditionalProps
       }
   )
 
@@ -315,7 +314,7 @@ export const UserAuthCard = ({
         ...additionalProps,
       })
 
-      if (isLoggedIn(flow)) {
+      if (isLoggedIn(flow) && additionalProps?.logoutURL) {
         message = {
           text: intl.formatMessage({
             id: "login.logout-label",
@@ -325,10 +324,10 @@ export const UserAuthCard = ({
             id: "login.logout-button",
             defaultMessage: "Logout",
           }),
-          url: additionalProps.logoutURL,
           dataTestId: "logout-link",
+          url: additionalProps.logoutURL,
         }
-      } else if (additionalProps.signupURL) {
+      } else if (additionalProps?.signupURL) {
         message = {
           text: intl.formatMessage({
             id: "login.registration-label",
@@ -350,17 +349,19 @@ export const UserAuthCard = ({
       $flow = RegistrationSection({
         nodes: flow.ui.nodes,
       })
-      message = {
-        text: intl.formatMessage({
-          id: "registration.login-label",
-          defaultMessage: "Already have an account?",
-        }),
-        url: additionalProps.loginURL,
-        buttonText: intl.formatMessage({
-          id: "registration.login-button",
-          defaultMessage: "Sign in",
-        }),
-        dataTestId: "cta-link",
+      if (additionalProps?.loginURL) {
+        message = {
+          text: intl.formatMessage({
+            id: "registration.login-label",
+            defaultMessage: "Already have an account?",
+          }),
+          url: additionalProps.loginURL,
+          buttonText: intl.formatMessage({
+            id: "registration.login-button",
+            defaultMessage: "Sign in",
+          }),
+          dataTestId: "cta-link",
+        }
       }
       break
     // both verification and recovery use the same flow.
@@ -368,24 +369,26 @@ export const UserAuthCard = ({
       $flow = LinkSection({
         nodes: flow.ui.nodes,
       })
-      message = {
-        text: intl.formatMessage({
-          id: "recovery.login-label",
-          defaultMessage: "Remember your credentials?",
-        }),
-        buttonText: intl.formatMessage({
-          id: "recovery.login-button",
-          defaultMessage: "Sign in",
-        }),
-        url: additionalProps.loginURL,
-        dataTestId: "cta-link",
+      if (additionalProps?.loginURL) {
+        message = {
+          text: intl.formatMessage({
+            id: "recovery.login-label",
+            defaultMessage: "Remember your credentials?",
+          }),
+          buttonText: intl.formatMessage({
+            id: "recovery.login-button",
+            defaultMessage: "Sign in",
+          }),
+          url: additionalProps.loginURL,
+          dataTestId: "cta-link",
+        }
       }
       break
     case "verification":
       $flow = LinkSection({
         nodes: flow.ui.nodes,
       })
-      if (additionalProps.signupURL) {
+      if (additionalProps?.signupURL) {
         message = {
           text: intl.formatMessage({
             id: "verification.registration-label",

--- a/src/react-components/ory/user-auth-card.tsx
+++ b/src/react-components/ory/user-auth-card.tsx
@@ -385,17 +385,19 @@ export const UserAuthCard = ({
       $flow = LinkSection({
         nodes: flow.ui.nodes,
       })
-      message = {
-        text: intl.formatMessage({
-          id: "verification.registration-label",
-          defaultMessage: "Don't have an account?",
-        }),
-        buttonText: intl.formatMessage({
-          id: "verification.registration-button",
-          defaultMessage: "Sign up",
-        }),
-        url: additionalProps.signupURL,
-        dataTestId: "cta-link",
+      if (additionalProps.signupURL) {
+        message = {
+          text: intl.formatMessage({
+            id: "verification.registration-label",
+            defaultMessage: "Don't have an account?",
+          }),
+          buttonText: intl.formatMessage({
+            id: "verification.registration-button",
+            defaultMessage: "Sign up",
+          }),
+          url: additionalProps.signupURL,
+          dataTestId: "cta-link",
+        }
       }
       break
     default:

--- a/src/stories/Ory/Auth.stories.tsx
+++ b/src/stories/Ory/Auth.stories.tsx
@@ -154,6 +154,13 @@ LoginAuthCardWithCodeSubmit.args = {
   },
 }
 
+export const LoginAuthCardWithoutAdditionalProps = Template.bind({})
+
+LoginAuthCardWithoutAdditionalProps.args = {
+  flow: loginFlow as LoginFlow,
+  flowType: "login",
+}
+
 export const RegistrationAuthCard = Template.bind({})
 
 RegistrationAuthCard.args = {
@@ -168,13 +175,18 @@ RegistrationAuthCard.args = {
 export const RegistrationAuthCardWebAuthn = Template.bind({})
 
 RegistrationAuthCardWebAuthn.args = {
-  title: "Create an account for Acme",
   flow: registrationFlowWebAuthn as RegistrationFlow,
   flowType: "registration",
   includeScripts: true,
   additionalProps: {
     loginURL: "https://acme.com/login",
   },
+}
+
+export const RegistrationAuthCardWithoutAdditionalProps = Template.bind({})
+RegistrationAuthCardWithoutAdditionalProps.args = {
+  flow: registrationFlow as RegistrationFlow,
+  flowType: "registration",
 }
 
 export const RecoveryAuthCard = Template.bind({})
@@ -186,6 +198,12 @@ RecoveryAuthCard.args = {
   additionalProps: {
     loginURL: "https://acme.com/login",
   },
+}
+
+export const RecoveryAuthCardWithoutAdditionalProps = Template.bind({})
+RecoveryAuthCardWithoutAdditionalProps.args = {
+  flow: recoveryFlow as RecoveryFlow,
+  flowType: "recovery",
 }
 
 export const VerificationAuthCard = Template.bind({})
@@ -206,4 +224,11 @@ VerificationSubmittedAuthCard.args = {
   additionalProps: {
     signupURL: "https://acme.com/login",
   },
+}
+
+export const VerificationAuthCardWithoutAdditionalProps = Template.bind({})
+
+VerificationAuthCardWithoutAdditionalProps.args = {
+  flow: verificationFlow as VerificationFlow,
+  flowType: "verification",
 }


### PR DESCRIPTION
This PR addresses two minor issues:

1. Previously, after creating a login flow, its ID was not included in the query parameters, unlike the other flows.
2. The signup URL was always rendered, even when it was `undefined`. This resulted in an unclickable link. Additionally, this change allows users who haven't enabled registration to hide the URL.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
