### PR TITLE
fix: oidc redirect

### DIFF
--- a/examples/react-spa/src/sdk.ts
+++ b/examples/react-spa/src/sdk.ts
@@ -122,12 +122,14 @@ export const sdkError = (
             const currentUrl = new URL(window.location.href)
             const redirect = new URL(
               responseData.redirect_browser_to,
-              // need to add the base url since the `redirect_browser_to` is a relative url with no hostname
               window.location.origin,
             )
 
             // Path has changed
-            if (currentUrl.pathname !== redirect.pathname) {
+            if (
+              currentUrl.hostname === redirect.hostname &&
+              currentUrl.pathname !== redirect.pathname
+            ) {
               console.warn("sdkError 422: Update path")
               // remove /ui prefix from the path in case it is present (not setup correctly inside the project config)
               // since this is an SPA we don't need to redirect to the Account Experience.


### PR DESCRIPTION
The following statement in [line 125](https://github.com/ory/elements/blob/main/examples/react-spa/src/sdk.ts#L125) is not correct. When I log in via OIDC, I get redirected to:

```json
"redirect_browser_to": "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/authorize?client_id=<client_id>&login_hint=daniel.francesconi%40hgv.it&redirect_uri=https%3A%2F%2Fapi.accounts.hgv.it%2Fself-service%2Fmethods%2Foidc%2Fcallback%2Fmicrosoft&response_type=code&scope=https%3A%2F%2Fgraph.microsoft.com%2FUser.Read+openid&state="
```

Then, in [line 135](https://github.com/ory/elements/blob/main/examples/react-spa/src/sdk.ts#L135) the hostname `login.microsoftonline.com` is replaced with `localhost:3000`, generating the following URL:

```json
"http://localhost:3000/<tenant_id>/oauth2/v2.0/authorize?client_id=<client_id>&login_hint=daniel.francesconi%40hgv.it&redirect_uri=https%3A%2F%2Fapi.accounts.hgv.it%2Fself-service%2Fmethods%2Foidc%2Fcallback%2Fmicrosoft&response_type=code&scope=https%3A%2F%2Fgraph.microsoft.com%2FUser.Read+openid&state=<state>"
```

As a result, I am no longer properly redirected, and instead, a blank page is displayed.

## Related Issue or Design Document

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
