### PR TITLE
revert: disable button on submit

### DIFF
--- a/src/assets/passwordInput.js
+++ b/src/assets/passwordInput.js
@@ -26,9 +26,3 @@ document.getElementsByName("password").forEach((p) => {
     })
   }
 })
-
-document.querySelectorAll(`*[data-disable-on-click]`).forEach((p) => {
-  p.addEventListener("click", function () {
-    p.disabled = true
-  })
-})

--- a/src/react-components/ory/user-logout-card.tsx
+++ b/src/react-components/ory/user-logout-card.tsx
@@ -71,7 +71,6 @@ export const UserLogoutCard = ({
               type="submit"
               id="accept"
               value="Yes"
-              data-disable-on-click
               name="submit"
               variant="semibold"
               header={intl.formatMessage({


### PR DESCRIPTION
Reverts ory/elements#171

This didn't actually work. The reason is, that the click event fires before the submit event of the enclosing form, and disabling the button in the event stops event propagation.
There are a few [solutions](https://stackoverflow.com/a/5691065), but IMO we should just get this right in AX2 before spending any more time on this. The underlying issue is fixed either way, and this was purely cosmetic. (From https://github.com/ory/elements/pull/171#issuecomment-1866225524)