### PR TITLE
Fix react example redirect

### DIFF
--- a/examples/react-spa/src/sdk.ts
+++ b/examples/react-spa/src/sdk.ts
@@ -122,7 +122,7 @@ export const sdkError = (
             const currentUrl = new URL(window.location.href)
             const redirect = new URL(
               responseData.redirect_browser_to,
-              // need to add the base url since the `redirect_browser_to` is a relative url with no hostname
+              // need to add the base url since the `redirect_browser_to` may be a relative url with no hostname
               window.location.origin,
             )
 
@@ -132,9 +132,7 @@ export const sdkError = (
               // remove /ui prefix from the path in case it is present (not setup correctly inside the project config)
               // since this is an SPA we don't need to redirect to the Account Experience.
               redirect.pathname = redirect.pathname.replace("/ui", "")
-              navigate(redirect.pathname + redirect.search, {
-                replace: true,
-              })
+              window.location.assign(redirect.toString())
               return Promise.resolve()
             }
 


### PR DESCRIPTION
The react example didn't work if you configured the UI to be on the different (sub)domain or port than the Ory Tunnel.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
