### PR TITLE
feat: allow passing translations to ComponentWrapper

### DIFF
--- a/src/markup-components/component-wrapper.tsx
+++ b/src/markup-components/component-wrapper.tsx
@@ -3,20 +3,21 @@
 
 import { FunctionComponent } from "react"
 import ReactDOMServer from "react-dom/server"
-import { IntlProvider } from "../react-components"
-import * as locales from "../locales"
+import {
+  CustomTranslations,
+  IntlProvider,
+  SupportedTranslations,
+} from "../react-components"
 
-export type Context = {
-  locale?: keyof typeof locales
-}
+export type Context = SupportedTranslations | CustomTranslations
 
 export const ComponentWrapper = <Props extends {}>(
   Component: FunctionComponent<Props>,
   props: Props,
-  { locale = "en" }: Context,
+  ctx: Context,
 ) => {
   return ReactDOMServer.renderToStaticMarkup(
-    <IntlProvider locale={locale}>
+    <IntlProvider<typeof ctx> {...ctx}>
       <Component {...props} />
     </IntlProvider>,
   )


### PR DESCRIPTION
This PR allows users to pass custom translations to markup components using the `ComponentWrapper`.

## Related Issue or Design Document

Fixes ory/elements-legacy#11 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).