### PR TITLE
feat: expose get flow factory

### DIFF
--- a/examples/nextjs-app-router/app/auth/login/page.tsx
+++ b/examples/nextjs-app-router/app/auth/login/page.tsx
@@ -5,10 +5,11 @@ import { Login } from "@ory/elements-react/theme"
 import { enhanceOryConfig } from "@ory/nextjs"
 import { getLoginFlow, OryPageParams } from "@ory/nextjs/app"
 
-import config from "@/ory.config"
+import baseConfig from "@/ory.config"
 
 export default async function LoginPage(props: OryPageParams) {
-  const flow = await getLoginFlow(props.searchParams)
+  const config = enhanceOryConfig(baseConfig)
+  const flow = await getLoginFlow(config, props.searchParams)
 
   if (!flow) {
     return null
@@ -17,7 +18,7 @@ export default async function LoginPage(props: OryPageParams) {
   return (
     <Login
       flow={flow}
-      config={enhanceOryConfig(config)}
+      config={config}
       components={{
         Card: {},
       }}

--- a/examples/nextjs-app-router/app/auth/recovery/page.tsx
+++ b/examples/nextjs-app-router/app/auth/recovery/page.tsx
@@ -4,12 +4,13 @@
 import { Recovery } from "@ory/elements-react/theme"
 import { enhanceOryConfig } from "@ory/nextjs"
 import { getRecoveryFlow, OryPageParams } from "@ory/nextjs/app"
-
 import CustomCardHeader from "@/components/custom-card-header"
-import config from "@/ory.config"
+
+import baseConfig from "@/ory.config"
 
 export default async function RecoveryPage(props: OryPageParams) {
-  const flow = await getRecoveryFlow(props.searchParams)
+  const config = enhanceOryConfig(baseConfig)
+  const flow = await getRecoveryFlow(config, props.searchParams)
 
   if (!flow) {
     return null
@@ -18,7 +19,7 @@ export default async function RecoveryPage(props: OryPageParams) {
   return (
     <Recovery
       flow={flow}
-      config={enhanceOryConfig(config)}
+      config={config}
       components={{
         Card: {
           Header: CustomCardHeader,

--- a/examples/nextjs-app-router/app/auth/registration/page.tsx
+++ b/examples/nextjs-app-router/app/auth/registration/page.tsx
@@ -5,10 +5,11 @@ import { Registration } from "@ory/elements-react/theme"
 import { enhanceOryConfig } from "@ory/nextjs"
 import { getRegistrationFlow, OryPageParams } from "@ory/nextjs/app"
 
-import config from "@/ory.config"
+import baseConfig from "@/ory.config"
 
 export default async function RegistrationPage(props: OryPageParams) {
-  const flow = await getRegistrationFlow(props.searchParams)
+  const config = enhanceOryConfig(baseConfig)
+  const flow = await getRegistrationFlow(config, props.searchParams)
 
   if (!flow) {
     return null
@@ -17,7 +18,7 @@ export default async function RegistrationPage(props: OryPageParams) {
   return (
     <Registration
       flow={flow}
-      config={enhanceOryConfig(config)}
+      config={config}
       components={{
         Card: {},
       }}

--- a/examples/nextjs-app-router/app/auth/verification/page.tsx
+++ b/examples/nextjs-app-router/app/auth/verification/page.tsx
@@ -4,12 +4,13 @@
 import { Verification } from "@ory/elements-react/theme"
 import { enhanceOryConfig } from "@ory/nextjs"
 import { getVerificationFlow, OryPageParams } from "@ory/nextjs/app"
-
 import CustomCardHeader from "@/components/custom-card-header"
-import config from "@/ory.config"
+
+import baseConfig from "@/ory.config"
 
 export default async function VerificationPage(props: OryPageParams) {
-  const flow = await getVerificationFlow(props.searchParams)
+  const config = enhanceOryConfig(baseConfig)
+  const flow = await getVerificationFlow(config, props.searchParams)
 
   if (!flow) {
     return null
@@ -18,7 +19,7 @@ export default async function VerificationPage(props: OryPageParams) {
   return (
     <Verification
       flow={flow}
-      config={enhanceOryConfig(config)}
+      config={config}
       components={{
         Card: {
           Header: CustomCardHeader,

--- a/examples/nextjs-app-router/app/settings/page.tsx
+++ b/examples/nextjs-app-router/app/settings/page.tsx
@@ -7,10 +7,11 @@ import { enhanceOryConfig } from "@ory/nextjs"
 import { getSettingsFlow, OryPageParams } from "@ory/nextjs/app"
 import "@ory/elements-react/theme/styles.css"
 
-import config from "@/ory.config"
+import baseConfig from "@/ory.config"
 
 export default async function SettingsPage(props: OryPageParams) {
-  const flow = await getSettingsFlow(props.searchParams)
+  const config = enhanceOryConfig(baseConfig)
+  const flow = await getSettingsFlow(config, props.searchParams)
 
   if (!flow) {
     return null
@@ -21,7 +22,7 @@ export default async function SettingsPage(props: OryPageParams) {
       <SessionProvider>
         <Settings
           flow={flow}
-          config={enhanceOryConfig(config)}
+          config={config}
           components={{
             Card: {},
           }}

--- a/packages/elements-react/src/theme/default/components/card/current-identifier-button.tsx
+++ b/packages/elements-react/src/theme/default/components/card/current-identifier-button.tsx
@@ -32,6 +32,7 @@ export function DefaultCurrentIdentifierButton() {
   const attributes = omit(nodeBackButton.attributes, [
     "autocomplete",
     "node_type",
+    "maxlength",
   ])
 
   return (

--- a/packages/nextjs/src/app/client.ts
+++ b/packages/nextjs/src/app/client.ts
@@ -5,11 +5,12 @@ import { Configuration, FrontendApi } from "@ory/client-fetch"
 
 import { orySdkUrl } from "../utils/sdk"
 
-export const serverSideFrontendClient = new FrontendApi(
-  new Configuration({
-    headers: {
-      Accept: "application/json",
-    },
-    basePath: orySdkUrl(),
-  }),
-)
+export const serverSideFrontendClient = () =>
+  new FrontendApi(
+    new Configuration({
+      headers: {
+        Accept: "application/json",
+      },
+      basePath: orySdkUrl(),
+    }),
+  )

--- a/packages/nextjs/src/app/flow.test.ts
+++ b/packages/nextjs/src/app/flow.test.ts
@@ -17,15 +17,19 @@ import { getPublicUrl } from "./utils"
 jest.mock("./utils", () => ({
   getPublicUrl: jest.fn(),
   toFlowParams: jest.fn().mockImplementation((params: QueryParams) => params),
+  startNewFlow: jest.requireActual("./utils").startNewFlow,
+  toGetFlowParameter: jest
+    .fn()
+    .mockImplementation((params: QueryParams) => params),
 }))
 
 jest.mock("./client", () => ({
-  serverSideFrontendClient: {
+  serverSideFrontendClient: jest.fn().mockReturnValue({
     getLoginFlowRaw: jest.fn(),
     getRegistrationFlowRaw: jest.fn(),
     getRecoveryFlowRaw: jest.fn(),
     getVerificationFlowRaw: jest.fn(),
-  },
+  }),
 }))
 
 jest.mock("next/navigation", () => ({
@@ -97,7 +101,7 @@ for (const tc of testCases) {
       const queryParams = {}
       await tc.fn(config, queryParams)
       expect(redirect).toHaveBeenCalledWith(
-        `https://example.com/self-service/${tc.flowType}/browser`,
+        `https://example.com/self-service/${tc.flowType}/browser?`,
         "replace",
       )
     })
@@ -136,7 +140,7 @@ for (const tc of testCases) {
       }
       ;(tc.m as jest.Mock).mockRejectedValue(new Error("error"))
       const result = await tc.fn(config, queryParams)
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
       expect(handleFlowError).toHaveBeenCalled()
     })
   })

--- a/packages/nextjs/src/app/flow.test.ts
+++ b/packages/nextjs/src/app/flow.test.ts
@@ -72,22 +72,22 @@ const testCases = [
   {
     fn: getLoginFlow,
     flowType: FlowType.Login,
-    m: serverSideFrontendClient.getLoginFlowRaw,
+    m: serverSideFrontendClient().getLoginFlowRaw,
   },
   {
     fn: getRegistrationFlow,
     flowType: FlowType.Registration,
-    m: serverSideFrontendClient.getRegistrationFlowRaw,
+    m: serverSideFrontendClient().getRegistrationFlowRaw,
   },
   {
     fn: getRecoveryFlow,
     flowType: FlowType.Recovery,
-    m: serverSideFrontendClient.getRecoveryFlowRaw,
+    m: serverSideFrontendClient().getRecoveryFlowRaw,
   },
   {
     fn: getVerificationFlow,
     flowType: FlowType.Verification,
-    m: serverSideFrontendClient.getVerificationFlowRaw,
+    m: serverSideFrontendClient().getVerificationFlowRaw,
   },
 ]
 

--- a/packages/nextjs/src/app/flow.test.ts
+++ b/packages/nextjs/src/app/flow.test.ts
@@ -44,6 +44,22 @@ jest.mock("@ory/client-fetch", () => {
     handleFlowError: jest.fn(),
   }
 })
+const config = {
+  name: "string",
+  sdk: {
+    url: "string",
+  },
+  project: {
+    registration_enabled: true,
+    verification_enabled: true,
+    recovery_enabled: true,
+    recovery_ui_url: "string",
+    registration_ui_url: "string",
+    verification_ui_url: "string",
+    login_ui_url: "string",
+    settings_ui_url: "string",
+  },
+}
 
 beforeEach(() => {
   ;(getPublicUrl as jest.Mock).mockResolvedValue("https://example.com")
@@ -79,7 +95,7 @@ for (const tc of testCases) {
   describe(`flowtype=${tc.flowType}`, () => {
     test("restarts flow if no id given", async () => {
       const queryParams = {}
-      await tc.fn(queryParams)
+      await tc.fn(config, queryParams)
       expect(redirect).toHaveBeenCalledWith(
         `https://example.com/self-service/${tc.flowType}/browser`,
         "replace",
@@ -90,7 +106,7 @@ for (const tc of testCases) {
       const queryParams = {
         refresh: "true",
       }
-      await tc.fn(queryParams)
+      await tc.fn(config, queryParams)
       expect(redirect).toHaveBeenCalledWith(
         `https://example.com/self-service/${tc.flowType}/browser?refresh=true`,
         "replace",
@@ -107,7 +123,7 @@ for (const tc of testCases) {
           bar: "https://ory.sh/",
         }),
       } as any)
-      const result = await tc.fn(queryParams)
+      const result = await tc.fn(config, queryParams)
       expect(result).toEqual({
         foo: "https://example.com/a",
         bar: "https://example.com/",
@@ -119,7 +135,7 @@ for (const tc of testCases) {
         flow: "1234",
       }
       ;(tc.m as jest.Mock).mockRejectedValue(new Error("error"))
-      const result = await tc.fn(queryParams)
+      const result = await tc.fn(config, queryParams)
       expect(result).toBeNull()
       expect(handleFlowError).toHaveBeenCalled()
     })

--- a/packages/nextjs/src/app/flow.ts
+++ b/packages/nextjs/src/app/flow.ts
@@ -30,9 +30,9 @@ export async function getFlowFactory<T extends object>(
   flowType: FlowType,
   baseUrl: string,
   route: string,
-  options?: {
+  options: {
     disableRewrite?: boolean
-  },
+  } = { disableRewrite: false },
 ): Promise<T | null | void> {
   // Guess our own public url using Next.js helpers. We need the hostname, port, and protocol.
   const onRestartFlow = (useFlowId?: string) => {
@@ -58,7 +58,7 @@ export async function getFlowFactory<T extends object>(
       .value()
       .then(
         (v: T): T =>
-          !options?.disableRewrite ? rewriteJsonResponse(v, baseUrl) : v,
+          options.disableRewrite ? v : rewriteJsonResponse(v, baseUrl),
       )
   } catch (error) {
     const errorHandler = handleFlowError({

--- a/packages/nextjs/src/app/flow.ts
+++ b/packages/nextjs/src/app/flow.ts
@@ -4,61 +4,50 @@
 import { redirect, RedirectType } from "next/navigation"
 import { FlowType, handleFlowError } from "@ory/client-fetch"
 
-import { getPublicUrl, onRedirect } from "./utils"
+import { init, onRedirect } from "./utils"
 import { QueryParams } from "../types"
-import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
 import { onValidationError } from "../utils/utils"
 import { rewriteJsonResponse } from "../utils/rewrite"
 import * as runtime from "@ory/client-fetch/src/runtime"
 
-export async function getFlow<T extends object>(
+export async function getFlowFactory<T extends object>(
   params: QueryParams,
   fetchFlowRaw: () => Promise<runtime.ApiResponse<T>>,
   flowType: FlowType,
+  baseUrl: string,
+  route: string,
 ): Promise<T | null | void> {
   // Guess our own public url using Next.js helpers. We need the hostname, port, and protocol.
-  const knownProxiedUrl = await getPublicUrl()
-  const url = guessPotentiallyProxiedOrySdkUrl({
-    knownProxiedUrl,
-  })
 
-  const onRestartFlow = () => {
-    const redirectTo = new URL(
-      "/self-service/" + flowType.toString() + "/browser",
-      url,
-    )
-    redirectTo.search = queryParamsToURLSearch(params).toString()
+  const onRestartFlow = (useFlowId?: string) => {
+    if (!useFlowId) {
+      return init(params, flowType, baseUrl)
+    }
+
+    const redirectTo = new URL(route, baseUrl)
+    redirectTo.search = new URLSearchParams({
+      ...params,
+      flow: useFlowId,
+    }).toString()
     return redirect(redirectTo.toString(), RedirectType.replace)
   }
 
   if (!params["flow"]) {
-    onRestartFlow()
-    return
+    return onRestartFlow()
   }
 
   try {
     const rawResponse = await fetchFlowRaw()
     return await rawResponse
       .value()
-      .then((v: T): T => rewriteJsonResponse(v, url))
+      .then((v: T): T => rewriteJsonResponse(v, baseUrl))
   } catch (error) {
     const errorHandler = handleFlowError({
       onValidationError,
       onRestartFlow,
       onRedirect: onRedirect,
     })
-    await errorHandler(error)
-    return null
-  }
-}
 
-function queryParamsToURLSearch(q: QueryParams) {
-  const url = new URLSearchParams()
-  for (const key in q) {
-    const v = q[key]
-    if (v) {
-      url.set(key, v.toString())
-    }
+    return await errorHandler(error)
   }
-  return url.toString()
 }

--- a/packages/nextjs/src/app/flow.ts
+++ b/packages/nextjs/src/app/flow.ts
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { redirect, RedirectType } from "next/navigation"
-import { FlowType, handleFlowError } from "@ory/client-fetch"
+import { FlowType, handleFlowError, ApiResponse } from "@ory/client-fetch"
 
-import { init, onRedirect } from "./utils"
+import { startNewFlow, onRedirect } from "./utils"
 import { QueryParams } from "../types"
 import { onValidationError } from "../utils/utils"
 import { rewriteJsonResponse } from "../utils/rewrite"
-import * as runtime from "@ory/client-fetch/src/runtime"
 
 /**
  * A function that creates a flow fetcher. The flow fetcher can be used
@@ -18,24 +17,23 @@ import * as runtime from "@ory/client-fetch/src/runtime"
  * Unless you are building something very custom, you will not need this method. Use it with care and expect
  * potential breaking changes.
  *
- * @param params
- * @param fetchFlowRaw
- * @param flowType
- * @param baseUrl
- * @param route
+ * @param params - The query parameters of the request.
+ * @param fetchFlowRaw - A function that fetches the flow from the SDK.
+ * @param flowType - The type of the flow.
+ * @param baseUrl - The base URL of the application.
+ * @param route - The route of the application.
  */
 export async function getFlowFactory<T extends object>(
   params: QueryParams,
-  fetchFlowRaw: () => Promise<runtime.ApiResponse<T>>,
+  fetchFlowRaw: () => Promise<ApiResponse<T>>,
   flowType: FlowType,
   baseUrl: string,
   route: string,
 ): Promise<T | null | void> {
   // Guess our own public url using Next.js helpers. We need the hostname, port, and protocol.
-
   const onRestartFlow = (useFlowId?: string) => {
     if (!useFlowId) {
-      return init(params, flowType, baseUrl)
+      return startNewFlow(params, flowType, baseUrl)
     }
 
     const redirectTo = new URL(route, baseUrl)

--- a/packages/nextjs/src/app/flow.ts
+++ b/packages/nextjs/src/app/flow.ts
@@ -10,6 +10,20 @@ import { onValidationError } from "../utils/utils"
 import { rewriteJsonResponse } from "../utils/rewrite"
 import * as runtime from "@ory/client-fetch/src/runtime"
 
+/**
+ * A function that creates a flow fetcher. The flow fetcher can be used
+ * to fetch a login, registration, recovery, settings, or verification flow
+ * from the SDK.
+ *
+ * Unless you are building something very custom, you will not need this method. Use it with care and expect
+ * potential breaking changes.
+ *
+ * @param params
+ * @param fetchFlowRaw
+ * @param flowType
+ * @param baseUrl
+ * @param route
+ */
 export async function getFlowFactory<T extends object>(
   params: QueryParams,
   fetchFlowRaw: () => Promise<runtime.ApiResponse<T>>,

--- a/packages/nextjs/src/app/flow.ts
+++ b/packages/nextjs/src/app/flow.ts
@@ -22,6 +22,7 @@ import { rewriteJsonResponse } from "../utils/rewrite"
  * @param flowType - The type of the flow.
  * @param baseUrl - The base URL of the application.
  * @param route - The route of the application.
+ * @param options - Additional options.
  */
 export async function getFlowFactory<T extends object>(
   params: QueryParams,
@@ -29,6 +30,9 @@ export async function getFlowFactory<T extends object>(
   flowType: FlowType,
   baseUrl: string,
   route: string,
+  options?: {
+    disableRewrite?: boolean
+  },
 ): Promise<T | null | void> {
   // Guess our own public url using Next.js helpers. We need the hostname, port, and protocol.
   const onRestartFlow = (useFlowId?: string) => {
@@ -52,7 +56,10 @@ export async function getFlowFactory<T extends object>(
     const rawResponse = await fetchFlowRaw()
     return await rawResponse
       .value()
-      .then((v: T): T => rewriteJsonResponse(v, baseUrl))
+      .then(
+        (v: T): T =>
+          !options?.disableRewrite ? rewriteJsonResponse(v, baseUrl) : v,
+      )
   } catch (error) {
     const errorHandler = handleFlowError({
       onValidationError,

--- a/packages/nextjs/src/app/index.ts
+++ b/packages/nextjs/src/app/index.ts
@@ -9,5 +9,6 @@ export { getVerificationFlow } from "./verification"
 export { getSettingsFlow } from "./settings"
 export { getLogoutFlow } from "./logout"
 export { getServerSession } from "./session"
+export { getFlowFactory } from "./flow"
 
 export type { OryPageParams } from "./utils"

--- a/packages/nextjs/src/app/login.ts
+++ b/packages/nextjs/src/app/login.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { FlowType, LoginFlow } from "@ory/client-fetch"
 
-import { initOverrides, OryConfig, QueryParams } from "../types"
+import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
@@ -52,7 +52,7 @@ export async function getLoginFlow(
   return getFlowFactory(
     await params,
     async () =>
-      serverSideFrontendClient.getLoginFlowRaw(
+      serverSideFrontendClient().getLoginFlowRaw(
         await toGetFlowParameter(params),
         initOverrides,
       ),

--- a/packages/nextjs/src/app/login.ts
+++ b/packages/nextjs/src/app/login.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { FlowType, LoginFlow } from "@ory/client-fetch"
 
-import { initOverrides, QueryParams } from "../types"
+import { initOverrides, OryConfig, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
 import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
-import { useRouter } from "next/router"
+import { OryConfigForNextJS } from "../utils/config"
 
 /**
  * Use this method in an app router page to fetch an existing login flow or to create a new one. This method works with server-side rendering.
@@ -16,12 +16,13 @@ import { useRouter } from "next/router"
  * import { Login } from "@ory/elements-react/theme"
  * import { getLoginFlow, OryPageParams } from "@ory/nextjs/app"
  * import { enhanceConfig } from "@ory/nextjs"
- *
- * import config from "@/ory.config"
  * import CardHeader from "@/app/auth/login/card-header"
  *
+ * import baseConfig from "@/ory.config"
+ *
  * export default async function LoginPage(props: OryPageParams) {
- *   const flow = await getLoginFlow(props.searchParams)
+ *   const config = enhanceConfig(baseConfig)
+ *   const flow = await getLoginFlow(config, props.searchParams)
  *
  *   if (!flow) {
  *     return null
@@ -30,7 +31,7 @@ import { useRouter } from "next/router"
  *   return (
  *     <Login
  *       flow={flow}
- *       config={enhanceConfig(config)}
+ *       config={config}
  *       components={{
  *         Card: {
  *           Header: CardHeader,
@@ -41,13 +42,13 @@ import { useRouter } from "next/router"
  * }
  * ```
  *
+ * @param config - The Ory configuration object.
  * @param params - The query parameters of the request.
  */
 export async function getLoginFlow(
+  config: OryConfigForNextJS,
   params: QueryParams | Promise<QueryParams>,
 ): Promise<LoginFlow | null | void> {
-  const router = useRouter()
-  const currentRoute = router.pathname
   return getFlowFactory(
     await params,
     async () =>
@@ -59,6 +60,6 @@ export async function getLoginFlow(
     guessPotentiallyProxiedOrySdkUrl({
       knownProxiedUrl: await getPublicUrl(),
     }),
-    currentRoute,
+    config.project.login_ui_url,
   )
 }

--- a/packages/nextjs/src/app/login.ts
+++ b/packages/nextjs/src/app/login.ts
@@ -4,8 +4,10 @@ import { FlowType, LoginFlow } from "@ory/client-fetch"
 
 import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
-import { getFlow } from "./flow"
-import { toFlowParams } from "./utils"
+import { getFlowFactory } from "./flow"
+import { getPublicUrl, toGetFlowParameter } from "./utils"
+import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
+import { useRouter } from "next/router"
 
 /**
  * Use this method in an app router page to fetch an existing login flow or to create a new one. This method works with server-side rendering.
@@ -44,10 +46,19 @@ import { toFlowParams } from "./utils"
 export async function getLoginFlow(
   params: QueryParams | Promise<QueryParams>,
 ): Promise<LoginFlow | null | void> {
-  const p = await toFlowParams(await params)
-  return getFlow(
+  const router = useRouter()
+  const currentRoute = router.pathname
+  return getFlowFactory(
     await params,
-    () => serverSideFrontendClient.getLoginFlowRaw(p, initOverrides),
+    async () =>
+      serverSideFrontendClient.getLoginFlowRaw(
+        await toGetFlowParameter(params),
+        initOverrides,
+      ),
     FlowType.Login,
+    guessPotentiallyProxiedOrySdkUrl({
+      knownProxiedUrl: await getPublicUrl(),
+    }),
+    currentRoute,
   )
 }

--- a/packages/nextjs/src/app/logout.ts
+++ b/packages/nextjs/src/app/logout.ts
@@ -37,7 +37,7 @@ export async function getLogoutFlow({
   const url = guessPotentiallyProxiedOrySdkUrl({
     knownProxiedUrl,
   })
-  return serverSideFrontendClient
+  return serverSideFrontendClient()
     .createBrowserLogoutFlow({
       cookie: h.get("cookie") ?? "",
       returnTo,

--- a/packages/nextjs/src/app/recovery.ts
+++ b/packages/nextjs/src/app/recovery.ts
@@ -4,8 +4,10 @@ import { FlowType, RecoveryFlow } from "@ory/client-fetch"
 
 import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
-import { getFlow } from "./flow"
-import { toFlowParams } from "./utils"
+import { getFlowFactory } from "./flow"
+import { getPublicUrl, toGetFlowParameter } from "./utils"
+import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
+import { useRouter } from "next/router"
 
 /**
  * Use this method in an app router page to fetch an existing recovery flow or to create a new one. This method works with server-side rendering.
@@ -44,10 +46,19 @@ import { toFlowParams } from "./utils"
 export async function getRecoveryFlow(
   params: QueryParams | Promise<QueryParams>,
 ): Promise<RecoveryFlow | null | void> {
-  const p = await toFlowParams(await params)
-  return getFlow(
+  const router = useRouter()
+  const currentRoute = router.pathname
+  return getFlowFactory(
     await params,
-    () => serverSideFrontendClient.getRecoveryFlowRaw(p, initOverrides),
+    async () =>
+      serverSideFrontendClient.getRecoveryFlowRaw(
+        await toGetFlowParameter(params),
+        initOverrides,
+      ),
     FlowType.Recovery,
+    guessPotentiallyProxiedOrySdkUrl({
+      knownProxiedUrl: await getPublicUrl(),
+    }),
+    currentRoute,
   )
 }

--- a/packages/nextjs/src/app/recovery.ts
+++ b/packages/nextjs/src/app/recovery.ts
@@ -52,7 +52,7 @@ export async function getRecoveryFlow(
   return getFlowFactory(
     await params,
     async () =>
-      serverSideFrontendClient.getRecoveryFlowRaw(
+      serverSideFrontendClient().getRecoveryFlowRaw(
         await toGetFlowParameter(params),
         initOverrides,
       ),

--- a/packages/nextjs/src/app/recovery.ts
+++ b/packages/nextjs/src/app/recovery.ts
@@ -7,7 +7,7 @@ import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
 import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
-import { useRouter } from "next/router"
+import { OryConfigForNextJS } from "../utils/config"
 
 /**
  * Use this method in an app router page to fetch an existing recovery flow or to create a new one. This method works with server-side rendering.
@@ -21,7 +21,8 @@ import { useRouter } from "next/router"
  * import CardHeader from "@/app/auth/recovery/card-header"
  *
  * export default async function RecoveryPage(props: OryPageParams) {
- *   const flow = await getRecoveryFlow(props.searchParams)
+ *   const config = enhanceConfig(baseConfig)
+ *   const flow = await getRecoveryFlow(config, props.searchParams)
  *
  *   if (!flow) {
  *     return null
@@ -30,7 +31,7 @@ import { useRouter } from "next/router"
  *   return (
  *     <Recovery
  *       flow={flow}
- *       config={enhanceConfig(config)}
+ *       config={config}
  *       components={{
  *         Card: {
  *           Header: CardHeader,
@@ -41,13 +42,13 @@ import { useRouter } from "next/router"
  * }
  * ```
  *
+ * @param config - The Ory configuration object.
  * @param params - The query parameters of the request.
  */
 export async function getRecoveryFlow(
+  config: OryConfigForNextJS,
   params: QueryParams | Promise<QueryParams>,
 ): Promise<RecoveryFlow | null | void> {
-  const router = useRouter()
-  const currentRoute = router.pathname
   return getFlowFactory(
     await params,
     async () =>
@@ -59,6 +60,6 @@ export async function getRecoveryFlow(
     guessPotentiallyProxiedOrySdkUrl({
       knownProxiedUrl: await getPublicUrl(),
     }),
-    currentRoute,
+    config.project.recovery_ui_url,
   )
 }

--- a/packages/nextjs/src/app/registration.ts
+++ b/packages/nextjs/src/app/registration.ts
@@ -52,7 +52,7 @@ export async function getRegistrationFlow(
   return getFlowFactory(
     await params,
     async () =>
-      serverSideFrontendClient.getRegistrationFlowRaw(
+      serverSideFrontendClient().getRegistrationFlowRaw(
         await toGetFlowParameter(params),
         initOverrides,
       ),

--- a/packages/nextjs/src/app/registration.ts
+++ b/packages/nextjs/src/app/registration.ts
@@ -6,8 +6,8 @@ import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
-import { useRouter } from "next/router"
 import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
+import { OryConfigForNextJS } from "../utils/config"
 
 /**
  * Use this method in an app router page to fetch an existing registration flow or to create a new one. This method works with server-side rendering.
@@ -21,7 +21,8 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * import CardHeader from "@/app/auth/registration/card-header"
  *
  * export default async function RegistrationPage(props: OryPageParams) {
- *   const flow = await getRegistrationFlow(props.searchParams)
+ *   const config = enhanceConfig(baseConfig)
+ *   const flow = await getRegistrationFlow(config, props.searchParams)
  *
  *   if (!flow) {
  *     return null
@@ -30,7 +31,7 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  *   return (
  *     <Registration
  *       flow={flow}
- *       config={enhanceConfig(config)}
+ *       config={config}
  *       components={{
  *         Card: {
  *           Header: CardHeader,
@@ -41,13 +42,13 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * }
  * ```
  *
+ * @param config - The Ory configuration object.
  * @param params - The query parameters of the request.
  */
 export async function getRegistrationFlow(
+  config: OryConfigForNextJS,
   params: QueryParams | Promise<QueryParams>,
 ): Promise<RegistrationFlow | null | void> {
-  const router = useRouter()
-  const currentRoute = router.pathname
   return getFlowFactory(
     await params,
     async () =>
@@ -59,6 +60,6 @@ export async function getRegistrationFlow(
     guessPotentiallyProxiedOrySdkUrl({
       knownProxiedUrl: await getPublicUrl(),
     }),
-    currentRoute,
+    config.project.registration_ui_url,
   )
 }

--- a/packages/nextjs/src/app/session.ts
+++ b/packages/nextjs/src/app/session.ts
@@ -7,7 +7,7 @@ import { getCookieHeader } from "./utils"
 
 export async function getServerSession(): Promise<Session | null> {
   const cookie = await getCookieHeader()
-  return serverSideFrontendClient
+  return serverSideFrontendClient()
     .toSession({
       cookie,
     })

--- a/packages/nextjs/src/app/settings.ts
+++ b/packages/nextjs/src/app/settings.ts
@@ -4,8 +4,10 @@ import { FlowType, SettingsFlow } from "@ory/client-fetch"
 
 import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
-import { getFlow } from "./flow"
-import { toFlowParams } from "./utils"
+import { getFlowFactory } from "./flow"
+import { getPublicUrl, toGetFlowParameter } from "./utils"
+import { useRouter } from "next/router"
+import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
 
 /**
  * Use this method in an app router page to fetch an existing login flow or to create a new one. This method works with server-side rendering.
@@ -44,10 +46,19 @@ import { toFlowParams } from "./utils"
 export async function getSettingsFlow(
   params: QueryParams | Promise<QueryParams>,
 ): Promise<SettingsFlow | null | void> {
-  const p = await toFlowParams(await params)
-  return getFlow(
+  const router = useRouter()
+  const currentRoute = router.pathname
+  return getFlowFactory(
     await params,
-    () => serverSideFrontendClient.getSettingsFlowRaw(p, initOverrides),
+    async () =>
+      serverSideFrontendClient.getSettingsFlowRaw(
+        await toGetFlowParameter(params),
+        initOverrides,
+      ),
     FlowType.Settings,
+    guessPotentiallyProxiedOrySdkUrl({
+      knownProxiedUrl: await getPublicUrl(),
+    }),
+    currentRoute,
   )
 }

--- a/packages/nextjs/src/app/settings.ts
+++ b/packages/nextjs/src/app/settings.ts
@@ -6,8 +6,8 @@ import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
-import { useRouter } from "next/router"
 import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
+import { OryConfigForNextJS } from "../utils/config"
 
 /**
  * Use this method in an app router page to fetch an existing login flow or to create a new one. This method works with server-side rendering.
@@ -21,7 +21,8 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * import CardHeader from "@/app/auth/login/card-header"
  *
  * export default async function LoginPage(props: OryPageParams) {
- *   const flow = await getLoginFlow(props.searchParams)
+ *   const config = enhanceConfig(baseConfig)
+ *   const flow = await getLoginFlow(config, props.searchParams)
  *
  *   if (!flow) {
  *     return null
@@ -30,7 +31,7 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  *   return (
  *     <Login
  *       flow={flow}
- *       config={enhanceConfig(config)}
+ *       config={config}
  *       components={{
  *         Card: {
  *           Header: CardHeader,
@@ -41,13 +42,13 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * }
  * ```
  *
+ * @param config - The Ory configuration object.
  * @param params - The query parameters of the request.
  */
 export async function getSettingsFlow(
+  config: OryConfigForNextJS,
   params: QueryParams | Promise<QueryParams>,
 ): Promise<SettingsFlow | null | void> {
-  const router = useRouter()
-  const currentRoute = router.pathname
   return getFlowFactory(
     await params,
     async () =>
@@ -59,6 +60,6 @@ export async function getSettingsFlow(
     guessPotentiallyProxiedOrySdkUrl({
       knownProxiedUrl: await getPublicUrl(),
     }),
-    currentRoute,
+    config.project.settings_ui_url,
   )
 }

--- a/packages/nextjs/src/app/settings.ts
+++ b/packages/nextjs/src/app/settings.ts
@@ -52,7 +52,7 @@ export async function getSettingsFlow(
   return getFlowFactory(
     await params,
     async () =>
-      serverSideFrontendClient.getSettingsFlowRaw(
+      serverSideFrontendClient().getSettingsFlowRaw(
         await toGetFlowParameter(params),
         initOverrides,
       ),

--- a/packages/nextjs/src/app/utils.ts
+++ b/packages/nextjs/src/app/utils.ts
@@ -42,7 +42,11 @@ export interface OryPageParams {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
-export function init(params: QueryParams, flowType: FlowType, baseUrl: string) {
+export function startNewFlow(
+  params: QueryParams,
+  flowType: FlowType,
+  baseUrl: string,
+) {
   // Take advantage of the fact, that Ory handles the flow creation for us and redirects the user to the default
   // return to automatically if they're logged in already.
   return redirect(

--- a/packages/nextjs/src/app/utils.ts
+++ b/packages/nextjs/src/app/utils.ts
@@ -3,9 +3,8 @@
 import { FlowType, OnRedirectHandler } from "@ory/client-fetch"
 import { headers } from "next/headers"
 import { redirect, RedirectType } from "next/navigation"
-
-import { urlQueryToSearchParams } from "next/dist/shared/lib/router/utils/querystring"
 import { QueryParams } from "../types"
+import { ParsedUrlQuery } from "querystring"
 
 export async function getCookieHeader() {
   // eslint-disable-next-line @typescript-eslint/await-thenable -- types in the next SDK are wrong?
@@ -55,4 +54,35 @@ export function startNewFlow(
     ).toString(),
     RedirectType.replace,
   )
+}
+
+// Copied over from https://github.com/vercel/next.js/blob/dbd5e1b274d30f9107141475eba116a8118bc346/packages/next/src/shared/lib/router/utils/querystring.ts
+// to avoid relying on internal APIs
+function stringifyUrlQueryParam(param: unknown): string {
+  if (typeof param === "string") {
+    return param
+  }
+
+  if (
+    (typeof param === "number" && !isNaN(param)) ||
+    typeof param === "boolean"
+  ) {
+    return String(param)
+  } else {
+    return ""
+  }
+}
+
+export function urlQueryToSearchParams(query: ParsedUrlQuery): URLSearchParams {
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, stringifyUrlQueryParam(item))
+      }
+    } else {
+      searchParams.set(key, stringifyUrlQueryParam(value))
+    }
+  }
+  return searchParams
 }

--- a/packages/nextjs/src/app/utils.ts
+++ b/packages/nextjs/src/app/utils.ts
@@ -1,11 +1,15 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 import { headers } from "next/headers"
-import { redirect } from "next/navigation"
-import { OnRedirectHandler } from "@ory/client-fetch"
+import { redirect, RedirectType } from "next/navigation"
+import { FlowType, OnRedirectHandler } from "@ory/client-fetch"
 
 import { QueryParams } from "../types"
 import { toFlowParams as baseToFlowParams } from "../utils/utils"
+import {
+  searchParamsToUrlQuery,
+  urlQueryToSearchParams,
+} from "next/dist/shared/lib/router/utils/querystring"
 
 export async function getCookieHeader() {
   // eslint-disable-next-line @typescript-eslint/await-thenable -- types in the next SDK are wrong?
@@ -17,8 +21,13 @@ export const onRedirect: OnRedirectHandler = (url) => {
   redirect(url)
 }
 
-export async function toFlowParams(params: QueryParams) {
-  return baseToFlowParams(params, getCookieHeader)
+export async function toGetFlowParameter(
+  params: Promise<QueryParams> | QueryParams,
+) {
+  return {
+    id: (await params)["flow"]?.toString() ?? "",
+    cookie: await getCookieHeader(),
+  }
 }
 
 export async function getPublicUrl() {
@@ -31,4 +40,19 @@ export async function getPublicUrl() {
 
 export interface OryPageParams {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export function init(params: QueryParams, flowType: FlowType, baseUrl: string) {
+  // Take advantage of the fact, that Ory handles the flow creation for us and redirects the user to the default
+  // return to automatically if they're logged in already.
+  return redirect(
+    new URL(
+      "/self-service/" +
+        flowType.toString() +
+        "/browser?" +
+        urlQueryToSearchParams(params).toString(),
+      baseUrl,
+    ).toString(),
+    RedirectType.replace,
+  )
 }

--- a/packages/nextjs/src/app/utils.ts
+++ b/packages/nextjs/src/app/utils.ts
@@ -1,15 +1,11 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
+import { FlowType, OnRedirectHandler } from "@ory/client-fetch"
 import { headers } from "next/headers"
 import { redirect, RedirectType } from "next/navigation"
-import { FlowType, OnRedirectHandler } from "@ory/client-fetch"
 
+import { urlQueryToSearchParams } from "next/dist/shared/lib/router/utils/querystring"
 import { QueryParams } from "../types"
-import { toFlowParams as baseToFlowParams } from "../utils/utils"
-import {
-  searchParamsToUrlQuery,
-  urlQueryToSearchParams,
-} from "next/dist/shared/lib/router/utils/querystring"
 
 export async function getCookieHeader() {
   // eslint-disable-next-line @typescript-eslint/await-thenable -- types in the next SDK are wrong?

--- a/packages/nextjs/src/app/verification.ts
+++ b/packages/nextjs/src/app/verification.ts
@@ -4,8 +4,10 @@ import { FlowType, VerificationFlow } from "@ory/client-fetch"
 
 import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
-import { getFlow } from "./flow"
-import { toFlowParams } from "./utils"
+import { getFlowFactory } from "./flow"
+import { getPublicUrl, toGetFlowParameter } from "./utils"
+import { useRouter } from "next/router"
+import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
 
 /**
  * Use this method in an app router page to fetch an existing verification flow or to create a new one. This method works with server-side rendering.
@@ -44,10 +46,19 @@ import { toFlowParams } from "./utils"
 export async function getVerificationFlow(
   params: QueryParams | Promise<QueryParams>,
 ): Promise<VerificationFlow | null | void> {
-  const p = await toFlowParams(await params)
-  return getFlow(
+  const router = useRouter()
+  const currentRoute = router.pathname
+  return getFlowFactory(
     await params,
-    () => serverSideFrontendClient.getVerificationFlowRaw(p, initOverrides),
+    async () =>
+      serverSideFrontendClient.getVerificationFlowRaw(
+        await toGetFlowParameter(params),
+        initOverrides,
+      ),
     FlowType.Verification,
+    guessPotentiallyProxiedOrySdkUrl({
+      knownProxiedUrl: await getPublicUrl(),
+    }),
+    currentRoute,
   )
 }

--- a/packages/nextjs/src/app/verification.ts
+++ b/packages/nextjs/src/app/verification.ts
@@ -6,8 +6,8 @@ import { initOverrides, QueryParams } from "../types"
 import { serverSideFrontendClient } from "./client"
 import { getFlowFactory } from "./flow"
 import { getPublicUrl, toGetFlowParameter } from "./utils"
-import { useRouter } from "next/router"
 import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
+import { OryConfigForNextJS } from "../utils/config"
 
 /**
  * Use this method in an app router page to fetch an existing verification flow or to create a new one. This method works with server-side rendering.
@@ -21,7 +21,8 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * import CardHeader from "@/app/auth/verification/card-header"
  *
  * export default async function VerificationPage(props: OryPageParams) {
- *   const flow = await getVerificationFlow(props.searchParams)
+ *   const config = enhanceConfig(baseConfig)
+ *   const flow = await getVerificationFlow(config, props.searchParams)
  *
  *   if (!flow) {
  *     return null
@@ -30,7 +31,7 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  *   return (
  *     <Verification
  *       flow={flow}
- *       config={enhanceConfig(config)}
+ *       config={config}
  *       components={{
  *         Card: {
  *           Header: CardHeader,
@@ -41,13 +42,13 @@ import { guessPotentiallyProxiedOrySdkUrl } from "../utils/sdk"
  * }
  * ```
  *
+ * @param config - The Ory configuration object.
  * @param params - The query parameters of the request.
  */
 export async function getVerificationFlow(
+  config: OryConfigForNextJS,
   params: QueryParams | Promise<QueryParams>,
 ): Promise<VerificationFlow | null | void> {
-  const router = useRouter()
-  const currentRoute = router.pathname
   return getFlowFactory(
     await params,
     async () =>
@@ -59,6 +60,6 @@ export async function getVerificationFlow(
     guessPotentiallyProxiedOrySdkUrl({
       knownProxiedUrl: await getPublicUrl(),
     }),
-    currentRoute,
+    config.project.verification_ui_url,
   )
 }

--- a/packages/nextjs/src/app/verification.ts
+++ b/packages/nextjs/src/app/verification.ts
@@ -52,7 +52,7 @@ export async function getVerificationFlow(
   return getFlowFactory(
     await params,
     async () =>
-      serverSideFrontendClient.getVerificationFlowRaw(
+      serverSideFrontendClient().getVerificationFlowRaw(
         await toGetFlowParameter(params),
         initOverrides,
       ),

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -21,7 +21,7 @@ import { isProduction } from "./sdk"
 export function enhanceOryConfig(
   config: Partial<OryConfig>,
   forceSdkUrl?: string,
-) {
+): OryConfigForNextJS {
   let sdkUrl =
     forceSdkUrl ??
     process.env["NEXT_PUBLIC_ORY_SDK_URL"] ??
@@ -58,6 +58,24 @@ export function enhanceOryConfig(
       verification_ui_url:
         config.override?.verificationUiPath ?? "/ui/verification",
       login_ui_url: config.override?.loginUiPath ?? "/ui/login",
+      settings_ui_url: config.override?.settingsUiPath ?? "/ui/settings",
     },
+  }
+}
+
+export interface OryConfigForNextJS {
+  name: string
+  sdk: {
+    url: string
+  }
+  project: {
+    registration_enabled: boolean
+    verification_enabled: boolean
+    recovery_enabled: boolean
+    recovery_ui_url: string
+    registration_ui_url: string
+    verification_ui_url: string
+    login_ui_url: string
+    settings_ui_url: string
   }
 }


### PR DESCRIPTION
The `getFlowFactory` allows developers of the `@ory/nextjs` package to define their own get login, registration, verification, recovery, and settings fetch logic, while keeping all of the error handling and state transition logic intact.

Most people should use `getLoginFlow` and other variants instead.