### PR TITLE
feat: support SAML-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34590,7 +34590,7 @@
     },
     "packages/elements-react": {
       "name": "@ory/elements-react",
-      "version": "1.0.0-next.39",
+      "version": "0.0.0-pr.4a28a8f",
       "license": "Apache License 2.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.1.0",

--- a/packages/elements-react/.stub-responses/login/1fa/saml/credential-select-password.json
+++ b/packages/elements-react/.stub-responses/login/1fa/saml/credential-select-password.json
@@ -1,0 +1,120 @@
+{
+  "id": "04bd8a60-9c5a-47d3-a9ea-2de7a96c890e",
+  "organization_id": null,
+  "type": "browser",
+  "expires_at": "2025-03-27T10:35:44.768464Z",
+  "issued_at": "2025-03-27T09:35:44.768464Z",
+  "request_url": "https://xenodochial-agnesi-gju1uchpmf.projects.oryapis:8080/self-service/login/browser?aal=&refresh=&return_to=&organization=&via=",
+  "active": "identifier_first",
+  "ui": {
+    "action": "https://xenodochial-agnesi-gju1uchpmf.projects.oryapis:8080/self-service/login?flow=04bd8a60-9c5a-47d3-a9ea-2de7a96c890e",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "identifier_first",
+        "attributes": {
+          "name": "identifier",
+          "type": "hidden",
+          "value": "dev+orycye2eda2f162daf6142dd0.rk5ftpzyi4p0.416y8f5t3gn@ory.dev",
+          "required": true,
+          "autocomplete": "username webauthn",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "dwq955QyvjIi77pjb6+2sZL6gLNM3Tpj6Ix9lTw/dOlvvGYZ30jk1fkgR4mHai88LhyiLJl197n7iINApG9OEA==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace",
+              "provider_id": "gsuite"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "password",
+          "type": "password",
+          "required": true,
+          "autocomplete": "current-password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070001,
+            "text": "Password",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010022,
+            "text": "Sign in with password",
+            "type": "info"
+          }
+        }
+      }
+    ]
+  },
+  "created_at": "2025-03-27T09:35:44.770521Z",
+  "updated_at": "2025-03-27T09:35:44.770521Z",
+  "refresh": false,
+  "requested_aal": "aal1",
+  "state": "choose_method"
+}

--- a/packages/elements-react/.stub-responses/login/1fa/saml/credential-select.json
+++ b/packages/elements-react/.stub-responses/login/1fa/saml/credential-select.json
@@ -1,0 +1,81 @@
+{
+  "id": "1611cd6f-d484-4fec-a0d7-a121401fb764",
+  "organization_id": null,
+  "type": "browser",
+  "expires_at": "2025-03-27T10:35:45.025279Z",
+  "issued_at": "2025-03-27T09:35:45.025279Z",
+  "request_url": "https://affectionate-sammet-ja9jriame9.projects.oryapis:8080/self-service/login/browser?aal=&refresh=&return_to=&organization=&via=",
+  "active": "identifier_first",
+  "ui": {
+    "action": "https://affectionate-sammet-ja9jriame9.projects.oryapis:8080/self-service/login?flow=1611cd6f-d484-4fec-a0d7-a121401fb764",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "identifier_first",
+        "attributes": {
+          "name": "identifier",
+          "type": "hidden",
+          "value": "dev+orycye2eda2f162daf6142dd0.zaqy9ridd10.q8rtx620k2l@ory.dev",
+          "required": true,
+          "autocomplete": "username webauthn",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "7VscDS9pJylk82YrucKmme0eTIAt8RHHO81vcvzjbrZKgC9+hu8mlCq1LoXFsJGHE0EDTrFompwmJqBFSWKLOA==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace",
+              "provider_id": "gsuite"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "created_at": "2025-03-27T09:35:45.027877Z",
+  "updated_at": "2025-03-27T09:35:45.027877Z",
+  "refresh": false,
+  "requested_aal": "aal1",
+  "state": "choose_method"
+}

--- a/packages/elements-react/.stub-responses/login/1fa/saml/initial-form.json
+++ b/packages/elements-react/.stub-responses/login/1fa/saml/initial-form.json
@@ -1,0 +1,233 @@
+{
+  "id": "88f42b31-b992-4952-9fe9-480da716783f",
+  "organization_id": null,
+  "type": "browser",
+  "expires_at": "2025-03-27T10:35:43.93776851Z",
+  "issued_at": "2025-03-27T09:35:43.93776851Z",
+  "request_url": "https://exciting-pascal-qx0blfl2qh.projects.oryapis:8080/self-service/login/browser",
+  "ui": {
+    "action": "https://exciting-pascal-qx0blfl2qh.projects.oryapis:8080/self-service/login?flow=88f42b31-b992-4952-9fe9-480da716783f",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "auth0",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Auth0",
+            "type": "info",
+            "context": {
+              "provider": "Auth0",
+              "provider_id": "auth0"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "azure",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Azure AD",
+            "type": "info",
+            "context": {
+              "provider": "Azure AD",
+              "provider_id": "azure"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace",
+              "provider_id": "gsuite"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "okta",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with Okta",
+            "type": "info",
+            "context": {
+              "provider": "Okta",
+              "provider_id": "okta"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "onelogin",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with OneLogin",
+            "type": "info",
+            "context": {
+              "provider": "OneLogin",
+              "provider_id": "onelogin"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "pingfederate",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010002,
+            "text": "Sign in with PingFederate",
+            "type": "info",
+            "context": {
+              "provider": "PingFederate",
+              "provider_id": "pingfederate"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "5WXUb6G+GM6Y5C1J2iBBNZvxJg0485U7pgNa2t26DFxPZZmXX/VVJ8OewfeZszYNpznlo+fZGQ8hX99N8/f4+A==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "identifier",
+          "type": "text",
+          "value": "",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "password",
+          "type": "password",
+          "required": true,
+          "autocomplete": "current-password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070001,
+            "text": "Password",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1010022,
+            "text": "Sign in with password",
+            "type": "info"
+          }
+        }
+      }
+    ]
+  },
+  "created_at": "2025-03-27T09:35:43.94014Z",
+  "updated_at": "2025-03-27T09:35:43.94014Z",
+  "refresh": false,
+  "requested_aal": "aal1",
+  "state": "choose_method"
+}

--- a/packages/elements-react/.stub-responses/registration/one-step/saml/initial-form.json
+++ b/packages/elements-react/.stub-responses/registration/one-step/saml/initial-form.json
@@ -1,0 +1,292 @@
+{
+  "id": "6bd99aac-3ab6-4f4b-8fd8-2bc7e618366d",
+  "type": "browser",
+  "expires_at": "2025-03-27T09:43:04.912529881Z",
+  "issued_at": "2025-03-27T08:43:04.912529881Z",
+  "request_url": "https://competent-jang-5m3cavlsl8.projects.oryapis:8080/self-service/registration/browser",
+  "ui": {
+    "action": "https://competent-jang-5m3cavlsl8.projects.oryapis:8080/self-service/registration?flow=6bd99aac-3ab6-4f4b-8fd8-2bc7e618366d",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "auth0",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Auth0",
+            "type": "info",
+            "context": {
+              "provider": "Auth0",
+              "provider_id": "auth0"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "azure",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Azure AD",
+            "type": "info",
+            "context": {
+              "provider": "Azure AD",
+              "provider_id": "azure"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace",
+              "provider_id": "gsuite"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "okta",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Okta",
+            "type": "info",
+            "context": {
+              "provider": "Okta",
+              "provider_id": "okta"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "onelogin",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with OneLogin",
+            "type": "info",
+            "context": {
+              "provider": "OneLogin",
+              "provider_id": "onelogin"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "pingfederate",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with PingFederate",
+            "type": "info",
+            "context": {
+              "provider": "PingFederate",
+              "provider_id": "pingfederate"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "yDE7NLoEZR05K2GNg08gdmOMkY5C615/tF0FI9osLmvhN9M18HzsA0eT+0v5cpIbFkQxfklt90kl/RlJSgDwdg==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "traits.email",
+          "type": "email",
+          "required": true,
+          "autocomplete": "email",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "password",
+          "type": "password",
+          "required": true,
+          "autocomplete": "new-password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070001,
+            "text": "Password",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "traits.tos",
+          "type": "checkbox",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Accept the terms of service",
+            "type": "info",
+            "context": {
+              "title": "Accept the terms of service"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "traits.phone",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Phone Number",
+            "type": "info",
+            "context": {
+              "title": "Phone Number"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "traits.nested.name",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Name",
+            "type": "info",
+            "context": {
+              "title": "Name"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040001,
+            "text": "Sign up",
+            "type": "info"
+          }
+        }
+      }
+    ]
+  },
+  "organization_id": null,
+  "state": "choose_method"
+}

--- a/packages/elements-react/.stub-responses/registration/two-step/saml/initial-form.json
+++ b/packages/elements-react/.stub-responses/registration/two-step/saml/initial-form.json
@@ -1,0 +1,272 @@
+{
+  "id": "560c6085-c41d-477f-a4c3-d47fddb720c9",
+  "type": "browser",
+  "expires_at": "2025-03-27T10:17:24.705023667Z",
+  "issued_at": "2025-03-27T09:17:24.705023667Z",
+  "request_url": "https://xenodochial-bell-y8wdh57cz1.projects.oryapis:8080/self-service/registration/browser",
+  "ui": {
+    "action": "https://xenodochial-bell-y8wdh57cz1.projects.oryapis:8080/self-service/registration?flow=560c6085-c41d-477f-a4c3-d47fddb720c9",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "auth0",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Auth0",
+            "type": "info",
+            "context": {
+              "provider": "Auth0",
+              "provider_id": "auth0"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "azure",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Azure AD",
+            "type": "info",
+            "context": {
+              "provider": "Azure AD",
+              "provider_id": "azure"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace",
+              "provider_id": "gsuite"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "okta",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with Okta",
+            "type": "info",
+            "context": {
+              "provider": "Okta",
+              "provider_id": "okta"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "onelogin",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with OneLogin",
+            "type": "info",
+            "context": {
+              "provider": "OneLogin",
+              "provider_id": "onelogin"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "saml",
+        "attributes": {
+          "name": "provider",
+          "type": "submit",
+          "value": "pingfederate",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040002,
+            "text": "Sign up with PingFederate",
+            "type": "info",
+            "context": {
+              "provider": "PingFederate",
+              "provider_id": "pingfederate"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "traits.email",
+          "type": "email",
+          "required": true,
+          "autocomplete": "email",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "traits.tos",
+          "type": "checkbox",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Accept the terms of service",
+            "type": "info",
+            "context": {
+              "title": "Accept the terms of service"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "traits.phone",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Phone Number",
+            "type": "info",
+            "context": {
+              "title": "Phone Number"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "traits.nested.name",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Name",
+            "type": "info",
+            "context": {
+              "title": "Name"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "QALCi+UbEiYXVngugRP2IhkHpzm6fDMYAWDMimF70OWo9SCBpsKtQGJueUS1dZTZAzDZs3in5K43YaAkT9eINQ==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "profile",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1040001,
+            "text": "Sign up",
+            "type": "info"
+          }
+        }
+      }
+    ]
+  },
+  "organization_id": null,
+  "state": "choose_method"
+}

--- a/packages/elements-react/.stub-responses/settings/saml/with-provider.json
+++ b/packages/elements-react/.stub-responses/settings/saml/with-provider.json
@@ -1,0 +1,340 @@
+{
+  "id": "49549d58-9212-4581-a3c6-05282e0db767",
+  "type": "browser",
+  "expires_at": "2025-03-27T09:43:05.864445673Z",
+  "issued_at": "2025-03-27T08:43:05.864445673Z",
+  "request_url": "https://nice-driscoll-a19ob17c25.projects.oryapis:8080/self-service/settings/browser",
+  "ui": {
+    "action": "https://nice-driscoll-a19ob17c25.projects.oryapis:8080/self-service/settings?flow=49549d58-9212-4581-a3c6-05282e0db767",
+    "method": "POST",
+    "nodes": [
+      {
+        "type": "input",
+        "group": "default",
+        "attributes": {
+          "name": "csrf_token",
+          "type": "hidden",
+          "value": "6xs5Y4P53eXya/G/f6wpDUQx8bAa9BpSwSZ/fkzPlVGX4uIW9O8SmuFsA7p/Cby0KS8cTL3DPL4ncCgFhwzG1w==",
+          "required": true,
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {}
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "traits.email",
+          "type": "email",
+          "value": "dev+orycye2eda2f162daf6142dd0.prum2miwjk0.l6p2zyg6lp@ory.dev",
+          "required": true,
+          "autocomplete": "email",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "E-Mail",
+            "type": "info",
+            "context": {
+              "title": "E-Mail"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "traits.tos",
+          "type": "checkbox",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Accept the terms of service",
+            "type": "info",
+            "context": {
+              "title": "Accept the terms of service"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "traits.phone",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Phone Number",
+            "type": "info",
+            "context": {
+              "title": "Phone Number"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "traits.nested.name",
+          "type": "text",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070002,
+            "text": "Name",
+            "type": "info",
+            "context": {
+              "title": "Name"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "profile",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "profile",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070003,
+            "text": "Save",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "password",
+          "type": "password",
+          "required": true,
+          "autocomplete": "new-password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070001,
+            "text": "Password",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "password",
+        "attributes": {
+          "name": "method",
+          "type": "submit",
+          "value": "password",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1070003,
+            "text": "Save",
+            "type": "info"
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "link",
+          "type": "submit",
+          "value": "auth0",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050002,
+            "text": "Link Auth0",
+            "type": "info",
+            "context": {
+              "provider": "Auth0"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "link",
+          "type": "submit",
+          "value": "azure",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050002,
+            "text": "Link Azure AD",
+            "type": "info",
+            "context": {
+              "provider": "Azure AD"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "unlink",
+          "type": "submit",
+          "value": "gsuite",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050003,
+            "text": "Unlink Google Workspace",
+            "type": "info",
+            "context": {
+              "provider": "Google Workspace"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "link",
+          "type": "submit",
+          "value": "okta",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050002,
+            "text": "Link Okta",
+            "type": "info",
+            "context": {
+              "provider": "Okta"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "link",
+          "type": "submit",
+          "value": "onelogin",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050002,
+            "text": "Link OneLogin",
+            "type": "info",
+            "context": {
+              "provider": "OneLogin"
+            }
+          }
+        }
+      },
+      {
+        "type": "input",
+        "group": "oidc",
+        "attributes": {
+          "name": "link",
+          "type": "submit",
+          "value": "pingfederate",
+          "disabled": false,
+          "node_type": "input"
+        },
+        "messages": [],
+        "meta": {
+          "label": {
+            "id": 1050002,
+            "text": "Link PingFederate",
+            "type": "info",
+            "context": {
+              "provider": "PingFederate"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "identity": {
+    "id": "3a04b1a8-37aa-4794-8c18-fae7454e6074",
+    "schema_id": "3295c9e92d19a78b10bfa45d7619eedcfb7d7ea4c2e8f163a21613da0ae6d4179f47fb58d1c23060f11126585f380ee9a9ce9a1d451f4b4de9ef33cc93ca763f",
+    "schema_url": "https://nice-driscoll-a19ob17c25.projects.oryapis:8080/schemas/MzI5NWM5ZTkyZDE5YTc4YjEwYmZhNDVkNzYxOWVlZGNmYjdkN2VhNGMyZThmMTYzYTIxNjEzZGEwYWU2ZDQxNzlmNDdmYjU4ZDFjMjMwNjBmMTExMjY1ODVmMzgwZWU5YTljZTlhMWQ0NTFmNGI0ZGU5ZWYzM2NjOTNjYTc2M2Y",
+    "state": "active",
+    "state_changed_at": "2025-03-27T08:43:04.746124Z",
+    "traits": {
+      "email": "dev+orycye2eda2f162daf6142dd0.prum2miwjk0.l6p2zyg6lp@ory.dev"
+    },
+    "verifiable_addresses": [
+      {
+        "id": "9330e241-8be3-4114-901b-470220f03785",
+        "value": "dev+orycye2eda2f162daf6142dd0.prum2miwjk0.l6p2zyg6lp@ory.dev",
+        "verified": true,
+        "via": "email",
+        "status": "completed",
+        "verified_at": "2025-03-27T08:43:04.748643Z",
+        "created_at": "2025-03-27T08:43:04.74896Z",
+        "updated_at": "2025-03-27T08:43:04.74896Z"
+      }
+    ],
+    "recovery_addresses": [
+      {
+        "id": "6daa5013-7a83-4350-bb27-d43533d1ebaa",
+        "value": "dev+orycye2eda2f162daf6142dd0.prum2miwjk0.l6p2zyg6lp@ory.dev",
+        "via": "email",
+        "created_at": "2025-03-27T08:43:04.75281Z",
+        "updated_at": "2025-03-27T08:43:04.75281Z"
+      }
+    ],
+    "metadata_public": null,
+    "created_at": "2025-03-27T08:43:04.747101Z",
+    "updated_at": "2025-03-27T08:43:04.747101Z",
+    "organization_id": null
+  },
+  "state": "show_form"
+}

--- a/packages/elements-react/package.json
+++ b/packages/elements-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ory/elements-react",
-  "version": "1.0.0-next.39",
+  "version": "0.0.0-pr.4a28a8f",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/elements-react/src/components/form/social.tsx
+++ b/packages/elements-react/src/components/form/social.tsx
@@ -68,7 +68,7 @@ export function OryFormSocialButtonsForm() {
   } = useOryFlow()
 
   // Only get the oidc nodes.
-  const filteredNodes = ui.nodes.filter((node) => node.group === "oidc")
+  const filteredNodes = ui.nodes.filter((node) => node.group === UiNodeGroupEnum.Saml || node.group === UiNodeGroupEnum.Oidc)
 
   if (filteredNodes.length === 0) {
     return null

--- a/packages/elements-react/src/components/form/social.tsx
+++ b/packages/elements-react/src/components/form/social.tsx
@@ -68,7 +68,11 @@ export function OryFormSocialButtonsForm() {
   } = useOryFlow()
 
   // Only get the oidc nodes.
-  const filteredNodes = ui.nodes.filter((node) => node.group === UiNodeGroupEnum.Saml || node.group === UiNodeGroupEnum.Oidc)
+  const filteredNodes = ui.nodes.filter(
+    (node) =>
+      node.group === UiNodeGroupEnum.Saml ||
+      node.group === UiNodeGroupEnum.Oidc,
+  )
 
   if (filteredNodes.length === 0) {
     return null

--- a/packages/elements-react/stories/components/login/1fa/saml.stories.tsx
+++ b/packages/elements-react/stories/components/login/1fa/saml.stories.tsx
@@ -1,0 +1,114 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+import { LoginFlow, LoginFlowFromJSON } from "@ory/client-fetch"
+import type { Meta, StoryObj } from "@storybook/react"
+import { config } from "../../../utils"
+import { Login } from "../../../../src/theme/default"
+
+const samlNodes = LoginFlowFromJSON(
+  require("$snapshots/login/1fa/saml/initial-form.json"),
+)
+
+const providers = [
+  "okta",
+  "auth0",
+  "azure",
+  "onelogin",
+  "pingfederate",
+  "gsuite",
+]
+
+const listOnly = (providers: string[]): LoginFlow => {
+  return LoginFlowFromJSON({
+    ...samlNodes,
+    ui: {
+      ...samlNodes.ui,
+      nodes: samlNodes.ui.nodes.filter((node) => {
+        if (
+          node.group !== "saml" ||
+          node.attributes.node_type !== "input" ||
+          node.attributes.name !== "provider"
+        ) {
+          return true
+        }
+
+        return providers.includes(
+          (node.attributes.value as string).toLowerCase(),
+        )
+      }),
+    },
+  })
+}
+
+const meta = {
+  title: "Ory Elements/First Factor Login/Methods/SAML",
+  component: Login,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Login>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const OneSocialButton: Story = {
+  args: {
+    flow: listOnly(providers.slice(0, 1)),
+    config,
+  },
+}
+
+export const TwoSocialButtons: Story = {
+  args: {
+    flow: listOnly(providers.slice(0, 2)),
+    config,
+  },
+}
+
+export const ThreeSocialButtons: Story = {
+  args: {
+    flow: listOnly(providers.slice(0, 3)),
+    config,
+  },
+}
+
+export const FourSocialButtons: Story = {
+  args: {
+    flow: listOnly(providers.slice(0, 4)),
+    config,
+  },
+}
+
+export const FiveSocialButtons: Story = {
+  args: {
+    flow: listOnly(providers.slice(0, 5)),
+    config,
+  },
+}
+
+export const AllGenericButton: Story = {
+  args: {
+    flow: listOnly(providers),
+    config,
+  },
+}
+
+export const CredentialSelect: Story = {
+  args: {
+    flow: LoginFlowFromJSON(
+      require("$snapshots/login/1fa/saml/credential-select.json"),
+    ),
+    config,
+  },
+}
+
+export const CredentialSelectWithMethodSelect: Story = {
+  args: {
+    flow: LoginFlowFromJSON(
+      require("$snapshots/login/1fa/saml/credential-select-password.json"),
+    ),
+    config,
+  },
+}

--- a/packages/elements-react/stories/components/registration/one-step/saml.stories.ts
+++ b/packages/elements-react/stories/components/registration/one-step/saml.stories.ts
@@ -1,0 +1,28 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+import { config } from "../../../utils"
+import { LoginFlowFromJSON, RegistrationFlowFromJSON } from "@ory/client-fetch"
+import type { Meta, StoryObj } from "@storybook/react"
+import { Registration } from "../../../../src/theme/default"
+
+const meta = {
+  title: "Ory Elements/One Step Registration/Methods/SAML",
+  component: Registration,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Registration>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ShowForm: Story = {
+  args: {
+    flow: RegistrationFlowFromJSON(
+      require("$snapshots/registration/one-step/saml/initial-form.json"),
+    ),
+    config,
+  },
+}

--- a/packages/elements-react/stories/components/registration/one-step/saml.stories.ts
+++ b/packages/elements-react/stories/components/registration/one-step/saml.stories.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { config } from "../../../utils"
-import { LoginFlowFromJSON, RegistrationFlowFromJSON } from "@ory/client-fetch"
+import { RegistrationFlowFromJSON } from "@ory/client-fetch"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Registration } from "../../../../src/theme/default"
 

--- a/packages/elements-react/stories/components/registration/two-step/saml.stories.ts
+++ b/packages/elements-react/stories/components/registration/two-step/saml.stories.ts
@@ -1,0 +1,28 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+import { config } from "../../../utils"
+import { LoginFlowFromJSON, RegistrationFlowFromJSON } from "@ory/client-fetch"
+import type { Meta, StoryObj } from "@storybook/react"
+import { Registration } from "../../../../src/theme/default"
+
+const meta = {
+  title: "Ory Elements/Two Step Registration/Methods/SAML",
+  component: Registration,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Registration>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ShowForm: Story = {
+  args: {
+    flow: RegistrationFlowFromJSON(
+      require("$snapshots/registration/two-step/saml/initial-form.json"),
+    ),
+    config,
+  },
+}

--- a/packages/elements-react/stories/components/registration/two-step/saml.stories.ts
+++ b/packages/elements-react/stories/components/registration/two-step/saml.stories.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { config } from "../../../utils"
-import { LoginFlowFromJSON, RegistrationFlowFromJSON } from "@ory/client-fetch"
+import { RegistrationFlowFromJSON } from "@ory/client-fetch"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Registration } from "../../../../src/theme/default"
 


### PR DESCRIPTION
This PR implements support for Ory's native SAML integration by adding new Storybook stories and updating the filtering logic in the social buttons form.

- Added new Storybook stories for two-step registration, one-step registration, and first factor login using SAML.
- Updated the filtering logic in the social form component to include SAML nodes alongside OIDC nodes.