### PR TITLE
chore: remove unused value setter

### DIFF
--- a/packages/elements-react/src/components/form/nodes/input.tsx
+++ b/packages/elements-react/src/components/form/nodes/input.tsx
@@ -35,23 +35,9 @@ export const NodeInput = ({
   const isScreenSelectionNode =
     "name" in node.attributes && node.attributes.name === "screen"
 
-  const setFormValue = () => {
-    if (
-      attrs.value &&
-      !(
-        isResendNode ||
-        isScreenSelectionNode ||
-        node.group === UiNodeGroupEnum.Oauth2Consent
-      )
-    ) {
-      setValue(attrs.name, attrs.value)
-    }
-  }
-
   const hasRun = useRef(false)
   useEffect(
     () => {
-      setFormValue()
       if (!hasRun.current && onloadTrigger) {
         hasRun.current = true
         triggerToWindowCall(onloadTrigger)
@@ -63,7 +49,6 @@ export const NodeInput = ({
   )
 
   const handleClick: MouseEventHandler = () => {
-    setFormValue()
     if (onclickTrigger) {
       triggerToWindowCall(onclickTrigger)
     }


### PR DESCRIPTION
The value setter is probably (?) unneeded, because setValue is called by the theme components themselves.

The setValue useEffect is also removed, because this should really be in the form logic, not in the component logic (otherwise we get side effects on the form values).
