### PR TITLE
fix: resend not working for registration

### DIFF
--- a/packages/elements-react/src/components/form/form.tsx
+++ b/packages/elements-react/src/components/form/form.tsx
@@ -276,7 +276,8 @@ export function OryForm({
   }
 
   if (
-    (flowContainer.flowType === FlowType.Login || flowContainer.flowType === FlowType.Registration) &&
+    (flowContainer.flowType === FlowType.Login ||
+      flowContainer.flowType === FlowType.Registration) &&
     flowContainer.formState.current === "method_active" &&
     flowContainer.formState.method === "code"
   ) {


### PR DESCRIPTION
Fixes an issue where clicking on "resend code" on the registration screen twice would cause an error.