### PR TITLE
fix: correctly guess vercel environment

### DIFF
--- a/examples/nextjs-app-router/.env
+++ b/examples/nextjs-app-router/.env
@@ -1,1 +1,5 @@
+# This is an example project, please replace it with yours!
 NEXT_PUBLIC_ORY_SDK_URL=https://nervous-lewin-4edwdlsbyw.projects.oryapis.com
+
+# Set the API Token for support of SAML and OIDC.
+ORY_PROJECT_API_TOKEN=

--- a/examples/nextjs-app-router/README.md
+++ b/examples/nextjs-app-router/README.md
@@ -9,16 +9,29 @@ router.
    endpoints** URL
 4. Set `NEXT_PUBLIC_ORY_SDK_URL` in the `.env` file to your project's **API
    endpoints** URL
-5. Run `npm install`
-6. Run `npm run dev` and open navigate to http://localhost:3000
+5. Set `ORY_PROJECT_API_TOKEN` in the `.env` file to your project's **API
+   token**. You can create an
+   [API key in the Ory Console](https://www.ory.sh/docs/concepts/personal-access-token).
+6. Run `npm install`
+7. Run `npm run dev` and open navigate to http://localhost:3000
 
 <!-- prettier-ignore-start -->
 > [!WARNING]
-> For convenience Ory provides a default "playground" project, that
+> For convenience Ory provides a default "test" project, that
 > can be used to interact with Ory's APIs. It is a public project, that can be
 > used by anyone and data can be deleted at any time. Make sure to use a
 > dedicated project.
 <!-- prettier-ignore-end -->
+
+### Deploying to Vercel
+
+To successfully deploy to Vercel, you need to set the following environment
+variables in your Vercel project:
+
+- `NEXT_PUBLIC_ORY_SDK_URL` - The URL of your Ory project. This is the same URL
+  you set in your `.env` file.
+- `ORY_PROJECT_API_TOKEN` - The API token for your Ory project. This should be a
+  dedicated key for production.
 
 ## Features
 

--- a/examples/nextjs-pages-router/.env
+++ b/examples/nextjs-pages-router/.env
@@ -1,1 +1,5 @@
+# This is an example project, please replace it with yours!
 NEXT_PUBLIC_ORY_SDK_URL=https://nervous-lewin-4edwdlsbyw.projects.oryapis.com
+
+# Set the API Token for support of SAML and OIDC.
+ORY_PROJECT_API_TOKEN=

--- a/examples/nextjs-pages-router/README.md
+++ b/examples/nextjs-pages-router/README.md
@@ -9,8 +9,21 @@ router.
    endpoints** URL
 4. Set `NEXT_PUBLIC_ORY_SDK_URL` in the `.env` file to your project's **API
    endpoints** URL
-5. Run `npm install`
-6. Run `npm run dev` and open navigate to http://localhost:3000
+5. Set `ORY_PROJECT_API_TOKEN` in the `.env` file to your project's **API
+   token**. You can create an
+   [API key in the Ory Console](https://www.ory.sh/docs/concepts/personal-access-token).
+6. Run `npm install`
+7. Run `npm run dev` and open navigate to http://localhost:3000
+
+### Deploying to Vercel
+
+To successfully deploy to Vercel, you need to set the following environment
+variables in your Vercel project:
+
+- `NEXT_PUBLIC_ORY_SDK_URL` - The URL of your Ory project. This is the same URL
+  you set in your `.env` file.
+- `ORY_PROJECT_API_TOKEN` - The API token for your Ory project. This should be a
+  dedicated key for production.
 
 ## Features
 
@@ -24,7 +37,7 @@ router.
 
 <!-- prettier-ignore-start -->
 > [!WARNING]
-> For convenience Ory provides a default "playground" project, that
+> For convenience Ory provides a default "test" project, that
 > can be used to interact with Ory's APIs. It is a public project, that can be
 > used by anyone and data can be deleted at any time. Make sure to use a
 > dedicated project.

--- a/examples/nextjs-pages-router/pages/auth/login.tsx
+++ b/examples/nextjs-pages-router/pages/auth/login.tsx
@@ -1,7 +1,7 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 "use client"
-import { Login } from "@ory/elements-react/theme"
+import { DefaultCardLayout, Login } from "@ory/elements-react/theme"
 import { useLoginFlow } from "@ory/nextjs/pages"
 import { enhanceOryConfig } from "@ory/nextjs"
 import "@ory/elements-react/theme/styles.css"
@@ -16,7 +16,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="pt-4">
+    <DefaultCardLayout>
       <Login
         flow={flow}
         config={enhanceOryConfig(config)}
@@ -24,6 +24,6 @@ export default function LoginPage() {
           Card: {},
         }}
       />
-    </div>
+    </DefaultCardLayout>
   )
 }

--- a/examples/nextjs-pages-router/pages/auth/recovery.tsx
+++ b/examples/nextjs-pages-router/pages/auth/recovery.tsx
@@ -1,7 +1,7 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 "use client"
-import { Recovery } from "@ory/elements-react/theme"
+import { DefaultCardLayout, Recovery } from "@ory/elements-react/theme"
 import { useRecoveryFlow } from "@ory/nextjs/pages"
 import { enhanceOryConfig } from "@ory/nextjs"
 import "@ory/elements-react/theme/styles.css"
@@ -16,7 +16,7 @@ export default function RecoveryPage() {
   }
 
   return (
-    <div className="pt-4">
+    <DefaultCardLayout>
       <Recovery
         flow={flow}
         config={enhanceOryConfig(config)}
@@ -24,6 +24,6 @@ export default function RecoveryPage() {
           Card: {},
         }}
       />
-    </div>
+    </DefaultCardLayout>
   )
 }

--- a/examples/nextjs-pages-router/pages/auth/registration.tsx
+++ b/examples/nextjs-pages-router/pages/auth/registration.tsx
@@ -1,7 +1,7 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 "use client"
-import { Registration } from "@ory/elements-react/theme"
+import { DefaultCardLayout, Registration } from "@ory/elements-react/theme"
 import { useRegistrationFlow } from "@ory/nextjs/pages"
 import { enhanceOryConfig } from "@ory/nextjs"
 import "@ory/elements-react/theme/styles.css"
@@ -16,7 +16,7 @@ export default function RegistrationPage() {
   }
 
   return (
-    <div className="pt-4">
+    <DefaultCardLayout>
       <Registration
         flow={flow}
         config={enhanceOryConfig(config)}
@@ -24,6 +24,6 @@ export default function RegistrationPage() {
           Card: {},
         }}
       />
-    </div>
+    </DefaultCardLayout>
   )
 }

--- a/examples/nextjs-pages-router/pages/auth/verification.tsx
+++ b/examples/nextjs-pages-router/pages/auth/verification.tsx
@@ -1,7 +1,7 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 "use client"
-import { Verification } from "@ory/elements-react/theme"
+import { DefaultCardLayout, Verification } from "@ory/elements-react/theme"
 import { useVerificationFlow } from "@ory/nextjs/pages"
 import { enhanceOryConfig } from "@ory/nextjs"
 import "@ory/elements-react/theme/styles.css"
@@ -16,7 +16,7 @@ export default function VerificationPage() {
   }
 
   return (
-    <div className="pt-4">
+    <DefaultCardLayout>
       <Verification
         flow={flow}
         config={enhanceOryConfig(config)}
@@ -24,6 +24,6 @@ export default function VerificationPage() {
           Card: {},
         }}
       />
-    </div>
+    </DefaultCardLayout>
   )
 }

--- a/examples/nextjs-pages-router/pages/index.tsx
+++ b/examples/nextjs-pages-router/pages/index.tsx
@@ -19,7 +19,7 @@ function HomeContent() {
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
       <div className="flex flex-col items-center gap-4">
         <Image src={OryLogo as string} alt="Ory Logo" width={160} />
-        <h1 className="font-bold text-xl">Ory Next.js App Router Example</h1>
+        <h1 className="font-bold text-xl">Ory Next.js Pages Router Example</h1>
         {!session && (
           <div className="flex items-center gap-2 bg-white rounded border flex-col w-60 p-3">
             <Link className="underline block w-full" href="/auth/registration">

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,19 +1,37 @@
 # `@ory/nextjs`
 
-This package contains the Next.js SDK for Ory. It provides a set of React
-components, server-side components, and hooks to interact with the Ory
-ecosystem.
+This package contains the Next.js SDK for Ory. It is additive to the
+`@ory/elements-react` package and provides utility functions for the app and
+page router.
 
-Supports both app and page routers.
+This middleware expects environment variable `NEXT_PUBLIC_ORY_SDK_URL` to be set
+to your Ory Network Project SDK URL. This is the URL that you would use to
+access the Ory API.
+
+If you have a custom domain for your Ory Network Project, you should use the
+custom domain for `NEXT_PUBLIC_ORY_SDK_URL`.
 
 ## Installation
 
 Run `npm install @ory/nextjs` or `yarn add @ory/nextjs` to install the package.
 
-## Examples
+### Next.js middleware for local development and preview deployments
 
-See the [examples](../../examples) directory for examples on how to use the
-package.
+This package includes a middleware for the app and page router that enables
+local development and preview environments to work with Ory's cookie security
+model. When using the `@ory/nextjs` middleware, Ory Tunnel is not needed for
+development.
+
+Check the
+[app router](https://github.com/ory/elements/blob/main/examples/nextjs-app-router/middleware.ts)
+and
+[page router](https://github.com/ory/elements/blob/main/examples/nextjs-pages-router/middleware.ts)
+middleware example for more details.
+
+## Learn by example
+
+See the [examples](https://github.com/ory/elements/blob/main/examples) directory
+for examples on how to use the package.
 
 ## Development
 

--- a/packages/nextjs/src/utils/rewrite.ts
+++ b/packages/nextjs/src/utils/rewrite.ts
@@ -13,12 +13,21 @@ export function rewriteUrls(
 ) {
   for (const [_, [matchPath, replaceWith]] of [
     // TODO load these dynamically from the project config
+
+    // Old AX routes
     ["/ui/recovery", config.override?.recoveryUiPath],
     ["/ui/registration", config.override?.registrationUiPath],
     ["/ui/login", config.override?.loginUiPath],
     ["/ui/verification", config.override?.verificationUiPath],
     ["/ui/settings", config.override?.settingsUiPath],
     ["/ui/welcome", config.override?.defaultRedirectUri],
+
+    // New AX routes
+    ["/recovery", config.override?.recoveryUiPath],
+    ["/registration", config.override?.registrationUiPath],
+    ["/login", config.override?.loginUiPath],
+    ["/verification", config.override?.verificationUiPath],
+    ["/settings", config.override?.settingsUiPath],
   ].entries()) {
     const match = joinUrlPaths(matchBaseUrl, matchPath || "")
     if (replaceWith && source.startsWith(match)) {

--- a/packages/nextjs/src/utils/sdk.test.ts
+++ b/packages/nextjs/src/utils/sdk.test.ts
@@ -112,7 +112,9 @@ describe("guessPotentiallyProxiedOrySdkUrl", () => {
   it("should use NEXT_PUBLIC_VERCEL_URL when available", () => {
     process.env["VERCEL_ENV"] = "preview"
     process.env["NEXT_PUBLIC_VERCEL_URL"] = "public-myapp.vercel.app"
-    expect(guessPotentiallyProxiedOrySdkUrl()).toBe("https://public-myapp.vercel.app")
+    expect(guessPotentiallyProxiedOrySdkUrl()).toBe(
+      "https://public-myapp.vercel.app",
+    )
   })
 
   it("should use VERCEL_PROJECT_PRODUCTION_URL in production for vercel.app domains", () => {
@@ -125,9 +127,12 @@ describe("guessPotentiallyProxiedOrySdkUrl", () => {
   it("should prioritize NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL", () => {
     process.env["VERCEL_ENV"] = "production"
     process.env["NEXT_PUBLIC_ORY_SDK_URL"] = "https://example.com/"
-    process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] = "public-myapp.vercel.app"
+    process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] =
+      "public-myapp.vercel.app"
     process.env["VERCEL_PROJECT_PRODUCTION_URL"] = "myapp.vercel.app"
-    expect(guessPotentiallyProxiedOrySdkUrl()).toBe("https://public-myapp.vercel.app")
+    expect(guessPotentiallyProxiedOrySdkUrl()).toBe(
+      "https://public-myapp.vercel.app",
+    )
   })
 
   it("should ignore VERCEL_PROJECT_PRODUCTION_URL in production for non-vercel.app domains", () => {

--- a/packages/nextjs/src/utils/sdk.ts
+++ b/packages/nextjs/src/utils/sdk.ts
@@ -20,7 +20,10 @@ export function orySdkUrl() {
 export function isProduction() {
   return (
     ["production", "prod"].indexOf(
-      process.env["NEXT_PUBLIC_VERCEL_ENV"] ||  process.env["VERCEL_ENV"] || process.env["NODE_ENV"] || "",
+      process.env["NEXT_PUBLIC_VERCEL_ENV"] ||
+        process.env["VERCEL_ENV"] ||
+        process.env["NODE_ENV"] ||
+        "",
     ) > -1
   )
 }
@@ -39,13 +42,29 @@ export function guessPotentiallyProxiedOrySdkUrl(options?: {
     // The domain name of the generated deployment URL. Example: *.vercel.app. The value does not include the protocol scheme https://.
     //
     // This is only available for preview deployments on Vercel.
-    if (!isProduction() && (process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"])) {
-      return `https://${process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"]}`.replace(/\/$/, "")
+    if (
+      !isProduction() &&
+      (process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"])
+    ) {
+      return `https://${process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"]}`.replace(
+        /\/$/,
+        "",
+      )
     }
 
-    if (isProduction() && (process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] || process.env["VERCEL_PROJECT_PRODUCTION_URL"] || '').indexOf("vercel.app") > -1) {
+    if (
+      isProduction() &&
+      (
+        process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] ||
+        process.env["VERCEL_PROJECT_PRODUCTION_URL"] ||
+        ""
+      ).indexOf("vercel.app") > -1
+    ) {
       // This is a production deployment on Vercel. We are using the custom domain.
-      return `https://${process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] || process.env["VERCEL_PROJECT_PRODUCTION_URL"]}`.replace(/\/$/, "")
+      return `https://${process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] || process.env["VERCEL_PROJECT_PRODUCTION_URL"]}`.replace(
+        /\/$/,
+        "",
+      )
     }
 
     // This is sometimes set by the render server.

--- a/packages/nextjs/src/utils/sdk.ts
+++ b/packages/nextjs/src/utils/sdk.ts
@@ -28,11 +28,6 @@ export function isProduction() {
 export function guessPotentiallyProxiedOrySdkUrl(options?: {
   knownProxiedUrl?: string
 }) {
-  if (isProduction()) {
-    // In production, we use the production custom domain
-    return orySdkUrl()
-  }
-
   if (getEnv("VERCEL_ENV")) {
     // We are in vercel
 
@@ -44,7 +39,7 @@ export function guessPotentiallyProxiedOrySdkUrl(options?: {
 
     const productionUrl = getEnv("VERCEL_PROJECT_PRODUCTION_URL") || ""
     if (isProduction() && productionUrl.indexOf("vercel.app") > -1) {
-      // This is a production deployment on Vercel. We are using the custom domain.
+      // This is a production deployment on Vercel without a custom domain, so we use the vercel app domain.
       return `https://${productionUrl}`.replace(/\/$/, "")
     }
 
@@ -52,6 +47,11 @@ export function guessPotentiallyProxiedOrySdkUrl(options?: {
     if (process.env["__NEXT_PRIVATE_ORIGIN"]) {
       return process.env["__NEXT_PRIVATE_ORIGIN"].replace(/\/$/, "")
     }
+  }
+
+  if (isProduction()) {
+    // In production, we use the production custom domain
+    return orySdkUrl()
   }
 
   // Try to use window location

--- a/packages/nextjs/src/utils/sdk.ts
+++ b/packages/nextjs/src/utils/sdk.ts
@@ -20,7 +20,7 @@ export function orySdkUrl() {
 export function isProduction() {
   return (
     ["production", "prod"].indexOf(
-      process.env["VERCEL_ENV"] || process.env["NODE_ENV"] || "",
+      process.env["NEXT_PUBLIC_VERCEL_ENV"] ||  process.env["VERCEL_ENV"] || process.env["NODE_ENV"] || "",
     ) > -1
   )
 }
@@ -33,14 +33,19 @@ export function guessPotentiallyProxiedOrySdkUrl(options?: {
     return orySdkUrl()
   }
 
-  if (process.env["VERCEL_ENV"]) {
+  if (process.env["VERCEL_ENV"] || process.env["NEXT_PUBLIC_VERCEL_ENV"]) {
     // We are in vercel
 
     // The domain name of the generated deployment URL. Example: *.vercel.app. The value does not include the protocol scheme https://.
     //
     // This is only available for preview deployments on Vercel.
-    if (!isProduction() && process.env["VERCEL_URL"]) {
-      return `https://${process.env["VERCEL_URL"]}`.replace(/\/$/, "")
+    if (!isProduction() && (process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"])) {
+      return `https://${process.env["VERCEL_URL"] || process.env["NEXT_PUBLIC_VERCEL_URL"]}`.replace(/\/$/, "")
+    }
+
+    if (isProduction() && (process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] || process.env["VERCEL_PROJECT_PRODUCTION_URL"] || '').indexOf("vercel.app") > -1) {
+      // This is a production deployment on Vercel. We are using the custom domain.
+      return `https://${process.env["NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL"] || process.env["VERCEL_PROJECT_PRODUCTION_URL"]}`.replace(/\/$/, "")
     }
 
     // This is sometimes set by the render server.


### PR DESCRIPTION
Vercel publishes env vars sometimes prefixed, sometimes not with NEXT_PUBLIC_.

This patch tries to use both variants. Also, if a `vercel.app` domain is found, the middleware will do it's thing. Otherwise, it will use the custom domain.

Closes #482
