### PR TITLE
fix: update base hostname to be used from the header instead of using nextUrl host

### DIFF
--- a/packages/nextjs/src/middleware/middleware.ts
+++ b/packages/nextjs/src/middleware/middleware.ts
@@ -48,8 +48,10 @@ export async function proxyRequest(
     return NextResponse.next()
   }
 
+  const appBaseHost = request.headers.get("host");
+
   const matchBaseUrl = new URL(orySdkUrl())
-  const selfUrl = request.nextUrl.protocol + "//" + request.nextUrl.host
+  const selfUrl = request.nextUrl.protocol + "//" + (appBaseHost || request.nextUrl.host)
 
   const upstreamUrl = request.nextUrl.clone()
   upstreamUrl.hostname = matchBaseUrl.hostname

--- a/packages/nextjs/src/middleware/middleware.ts
+++ b/packages/nextjs/src/middleware/middleware.ts
@@ -48,10 +48,11 @@ export async function proxyRequest(
     return NextResponse.next()
   }
 
-  const appBaseHost = request.headers.get("host");
+  const appBaseHost = request.headers.get("host")
 
   const matchBaseUrl = new URL(orySdkUrl())
-  const selfUrl = request.nextUrl.protocol + "//" + (appBaseHost || request.nextUrl.host)
+  const selfUrl =
+    request.nextUrl.protocol + "//" + (appBaseHost || request.nextUrl.host)
 
   const upstreamUrl = request.nextUrl.clone()
   upstreamUrl.hostname = matchBaseUrl.hostname


### PR DESCRIPTION
Instead of using `localhost` as the `request_url` send the correct app URL to kratos to build a response. 

Before:
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/ffedde0e-d32f-4675-86b1-30c36959d88f" />

After
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/49768efe-01f1-4863-97fc-597cce1d0c1e" />
