### PR TITLE
feat(theme): add prefixed CSS

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,28 +122,31 @@ const config = tseslint.config([
     languageOptions: {
       parserOptions: {
         ecmaFeatures: {
-          jsx: true
-        }
-      }
+          jsx: true,
+        },
+      },
     },
     plugins: {
       "react-hooks": reactHooks,
-      'better-tailwindcss': eslintPluginBetterTailwindcss,
+      "better-tailwindcss": eslintPluginBetterTailwindcss,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       // enable all recommended rules to report an error
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
       "better-tailwindcss/enforce-consistent-line-wrapping": "off",
-      "better-tailwindcss/no-unregistered-classes": ["error", { ignore: ["ory-elements"] }],
+      "better-tailwindcss/no-unregistered-classes": [
+        "error",
+        { ignore: ["ory-elements"] },
+      ],
     },
     settings: {
       "better-tailwindcss": {
         // // tailwindcss 4: the path to the entry file of the css based tailwind config (eg: `src/global.css`)
-        "entryPoint": "packages/elements-react/src/theme/default/global.css",
+        entryPoint: "packages/elements-react/src/theme/default/global.css",
         // tailwindcss 3: the path to the tailwind config file (eg: `tailwind.config.js`)
         // "tailwindConfig": "/Users/jonas.hungershausen/Repositories/cloud/elements/packages/elements-react/tailwind.config.ts"
-      }
+      },
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -135,6 +135,7 @@ const config = tseslint.config([
       // enable all recommended rules to report an error
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
       "better-tailwindcss/enforce-consistent-line-wrapping": "off",
+      "better-tailwindcss/no-unregistered-classes": ["error", { ignore: ["ory-elements"] }],
     },
     settings: {
       "better-tailwindcss": {

--- a/examples/nextjs-app-router/postcss.config.mjs
+++ b/examples/nextjs-app-router/postcss.config.mjs
@@ -2,7 +2,7 @@
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},
-  }
+  },
 }
 
 export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -16951,6 +16951,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
@@ -29562,6 +29574,29 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-scope": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/postcss-scope/-/postcss-scope-1.7.4.tgz",
+      "integrity": "sha512-qZ7miyYDK6E5TLU1QL4a0baAVnX0CeI90YIz17fLSDsCU/F9m2Y2U3+QdTJ2x/Rvk3G0qqB1KHqmkEFfmtFxGg==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^8.4.48",
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -34353,6 +34388,7 @@
         "esbuild-plugin-svgr": "3.1.1",
         "eslint-plugin-react": "7.37.5",
         "postcss": "8.4.47",
+        "postcss-scope": "^1.7.4",
         "tailwindcss-animate": "1.0.7",
         "tsup": "8.4.0",
         "typedoc": "0.28.5"

--- a/packages/elements-react/package.json
+++ b/packages/elements-react/package.json
@@ -69,6 +69,7 @@
     "esbuild-plugin-svgr": "3.1.1",
     "eslint-plugin-react": "7.37.5",
     "postcss": "8.4.47",
+    "postcss-scope": "^1.7.4",
     "tailwindcss-animate": "1.0.7",
     "tsup": "8.4.0",
     "typedoc": "0.28.5"

--- a/packages/elements-react/postcss.config.ts
+++ b/packages/elements-react/postcss.config.ts
@@ -3,5 +3,5 @@
 
 module.exports = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-require-imports
-  plugins: [require("@tailwindcss/postcss")()],
+  plugins: [require("@tailwindcss/postcss")(), require("postcss-scope")(".ory-elements")],
 }

--- a/packages/elements-react/postcss.config.ts
+++ b/packages/elements-react/postcss.config.ts
@@ -3,5 +3,8 @@
 
 module.exports = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-require-imports
-  plugins: [require("@tailwindcss/postcss")(), require("postcss-scope")(".ory-elements")],
+  plugins: [
+    require("@tailwindcss/postcss")(),
+    require("postcss-scope")(".ory-elements"),
+  ],
 }

--- a/packages/elements-react/src/tests/jest/setup.ts
+++ b/packages/elements-react/src/tests/jest/setup.ts
@@ -1,2 +1,5 @@
+// Copyright © 2025 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 import "@testing-library/jest-dom"
 // import "@testing-library/jest-dom/jest-globals"

--- a/packages/elements-react/src/theme/default/components/card/index.tsx
+++ b/packages/elements-react/src/theme/default/components/card/index.tsx
@@ -19,10 +19,12 @@ import { DefaultCurrentIdentifierButton } from "./current-identifier-button"
  */
 export function DefaultCard({ children }: OryCardProps) {
   return (
-    <div className="flex w-full flex-1 items-start justify-center font-sans-default sm:w-[480px] sm:max-w-[480px] sm:items-center">
-      <div className="relative grid w-full grid-cols-1 gap-8 border-b border-form-border-default bg-form-background-default px-8 py-12 sm:rounded-cards sm:border sm:px-12 sm:py-14">
-        {children}
-        <Badge />
+    <div className="ory-elements">
+      <div className="flex w-full flex-1 items-start justify-center font-sans-default sm:w-[480px] sm:max-w-[480px] sm:items-center">
+        <div className="relative grid w-full grid-cols-1 gap-8 border-b border-form-border-default bg-form-background-default px-8 py-12 sm:rounded-cards sm:border sm:px-12 sm:py-14">
+          {children}
+          <Badge />
+        </div>
       </div>
     </div>
   )

--- a/packages/elements-react/src/theme/default/flows/settings.tsx
+++ b/packages/elements-react/src/theme/default/flows/settings.tsx
@@ -68,10 +68,10 @@ export function Settings({
       components={components}
     >
       {children ?? (
-        <>
+        <div className="ory-elements">
           <OryPageHeader />
           <OrySettingsCard />
-        </>
+        </div>
       )}
     </OryProvider>
   )

--- a/packages/elements-react/tailwind/generated/variables.css
+++ b/packages/elements-react/tailwind/generated/variables.css
@@ -1,3 +1,6 @@
+/* Copyright © 2025 Ory Corp */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @theme {
   --ui-100: #f1f5f9;
   --ui-200: #e2e8f0;


### PR DESCRIPTION
This should fix #566 by prepending a ".ory" before all selectors, meaning that every component can be wrapped in something that contains the class "ory" to apply the style.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments
It's definitely not the cleanest implementation, but it's absolutely transparent to the user. That said, it seems the new version of Tailwind styles misses some styles (like cursor: pointer; on buttons). But I can confirm I had the exact same render between "old global" and "prefixed" ones. Except the fonts, but well, that's another problem and I do not mind it too much!

Overall, the only "drawback" of this solution is that we have to add an element wrapping the components with the class "ory". It's not horrible, but still not the golden solution :/

### Before
<img width="670" height="907" alt="image" src="https://github.com/user-attachments/assets/d117eb10-a44d-466a-b114-854e1de3acd0" title="Before" />

### After
<img width="662" height="873" alt="image" src="https://github.com/user-attachments/assets/9be7f340-052e-45fb-9da2-e257a58a9a82" title="After" />

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
