### PR TITLE
fix: links to examples in examples

### DIFF
--- a/examples/nextjs-app-router/app/page.tsx
+++ b/examples/nextjs-app-router/app/page.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout() {
           )}
           <div className="flex gap-2 text-sm">
             <a
-              href="https://github.com/ory/elements/tree/master/examples/nextjs-pages-router"
+              href="https://github.com/ory/elements/tree/main/examples/nextjs-app-router"
               className="underline"
               target="_blank"
               rel="noreferrer"
@@ -69,7 +69,7 @@ export default async function RootLayout() {
               App Router Example
             </a>
             <a
-              href="https://github.com/ory/elements/tree/master/examples/nextjs-pages-router"
+              href="https://github.com/ory/elements/tree/main/examples/nextjs-pages-router"
               className="underline"
               target="_blank"
               rel="noreferrer"

--- a/examples/nextjs-pages-router/pages/index.tsx
+++ b/examples/nextjs-pages-router/pages/index.tsx
@@ -49,7 +49,7 @@ function HomeContent() {
         )}
         <div className="flex gap-2 text-sm">
           <a
-            href="https://github.com/ory/elements/tree/master/examples/nextjs-pages-router"
+            href="https://github.com/ory/elements/tree/main/examples/nextjs-app-router"
             className="underline"
             target="_blank"
             rel="noreferrer"
@@ -57,7 +57,7 @@ function HomeContent() {
             App Router Example
           </a>
           <a
-            href="https://github.com/ory/elements/tree/master/examples/nextjs-pages-router"
+            href="https://github.com/ory/elements/tree/main/examples/nextjs-pages-router"
             className="underline"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
The index pages in examples contains outdated self links to examples.
* branches: master -> main
* app-router-example falsely points to pages-router-example

## Related Issue or Design Document

n/a

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ x] I have referenced an issue containing the design document if my change introduces a new feature.
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] I have added the necessary documentation within the code base (if appropriate).

