### PR TITLE
Bug: startNewFlow uses absolute path "/self-service/...", breaks integrations mounted under a sub-path

### DIFF
--- a/packages/nextjs/src/app/utils.ts
+++ b/packages/nextjs/src/app/utils.ts
@@ -62,7 +62,7 @@ export function startNewFlow(
   // return to automatically if they're logged in already.
   return redirect(
     new URL(
-      "/self-service/" +
+      "self-service/" +
         flowType.toString() +
         "/browser?" +
         urlQueryToSearchParams(params).toString(),


### PR DESCRIPTION
## Preflight checklist

- [x] I could not find a solution in the existing issues, docs, nor discussions.
- [x] I agree to follow this project's [Code of Conduct](https://github.com/ory/nextjs/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and am following this repository's [Contribution Guidelines](https://github.com/ory/nextjs/blob/main/CONTRIBUTING.md).
- [x] This issue affects my Ory setup.
- [x] I have joined the [Ory Community Slack](https://slack.ory.sh).

## Ory Network Project

Self-hosted Ory Kratos (proxied through `@ory/nextjs` middleware).

## Describe the bug

`startNewFlow()` in `@ory/nextjs/app` builds the redirect URL with a **leading slash**:

```ts
new URL(
  "/self-service/" + flowType + "/browser?" + urlQueryToSearchParams(params).toString(),
  baseUrl,
)
```

Because the first argument starts with `/`, the URL constructor treats it as an
**absolute path** and **discards any path prefix carried by `baseUrl`**.

`baseUrl` here comes from `guessPotentiallyProxiedOrySdkUrl({ knownProxiedUrl: await getPublicUrl() })`,
which returns the public origin of the Next.js app (the URL the browser sees).
For any deployment where the Next.js app is **mounted under a sub-path** —
e.g. behind an ingress / reverse proxy that routes `https://example.com/app/*`
to the app, or when using Next.js `basePath` — the redirect drops the prefix
and points to `https://example.com/self-service/...` instead of
`https://example.com/app/self-service/...`. The middleware never sees the
request, the Kratos proxy never runs, and the user lands on a 404 (or worse,
an unrelated route on the parent domain).

This affects every flow that goes through `getFlowFactory` → `startNewFlow`:
login, registration, recovery, verification, settings.

The fix is to drop the leading `/` so the path is resolved **relative to
`baseUrl`**, which is the documented contract of `new URL(input, base)`:

```ts
new URL(
  "self-service/" + flowType + "/browser?" + urlQueryToSearchParams(params).toString(),
  baseUrl,
)
```

When `baseUrl` has no sub-path (the common case), the resulting URL is
identical, so this change is **backwards-compatible** for vanilla deployments
and **fixes** sub-path deployments.

## Reproducing the bug

1. Deploy a Next.js app using `@ory/nextjs` behind a reverse proxy that mounts
   it under a sub-path, e.g. `https://example.com/app/`. Make sure the proxy
   forwards `Host` / `X-Forwarded-*` headers so `getPublicUrl()` returns
   `https://example.com/app/`.
2. Visit `https://example.com/app/login` without an existing flow ID.
3. Observe the 30x redirect: `Location: https://example.com/self-service/login/browser?...`
   instead of `https://example.com/app/self-service/login/browser?...`.
4. The `@ory/nextjs` middleware (matched on `/app/self-service/*`) never runs,
   so the request never reaches Kratos and the browser hits a 404 / unrelated route.

The same problem occurs with Next.js `basePath: "/app"` configured in `next.config.ts`.

## Relevant log output

```text
GET /login 307
Location: https://example.com/self-service/login/browser?...
GET /self-service/login/browser 404
```

## Relevant configuration

```ts
// src/lib/ory.ts
export const oryConfig: OryClientConfiguration = {
  project: {
    login_ui_url: '/login',
    registration_ui_url: '/registration',
    // ...
  },
};
```

```ts
// src/middleware.ts
import { createOryMiddleware } from '@ory/nextjs/middleware';
export const middleware = createOryMiddleware(oryConfig);
```

## Version

`@ory/nextjs@1.0.0-rc.1`

## On which operating system are you observing this issue?

Linux (containerised, behind ingress)

## In which environment are you deploying?

Kubernetes (Helm), with an ingress mounting the app under a sub-path.

## Additional Context

Source location:
[`src/app/flow.ts` → `startNewFlow`](https://github.com/ory/nextjs/blob/main/src/app/flow.ts).

Spec reference for the URL constructor behavior:
https://url.spec.whatwg.org/#concept-url-parser — an input starting with `/`
is parsed as a path-absolute URL and replaces `base.pathname`.

I'm opening a PR with the one-character fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal URL routing path construction for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->